### PR TITLE
feat(document-details): add label to document title and fix design

### DIFF
--- a/addon/components/document-details.hbs
+++ b/addon/components/document-details.hbs
@@ -8,15 +8,27 @@
 >
   <div>
     <div class="uk-padding-small">
+      <div class="uk-flex uk-flex-between uk-flex-bottom">
+        <div class="uk-text-meta">
+          {{t "alexandria.document-details.document-title"}}
+        </div>
+        <LinkTo
+          @query={{hash document=undefined}}
+          class="uk-icon-button uk-flex-none"
+          uk-icon="close"
+          data-test-close
+        />
+      </div>
+
       <span
-        class="document-title uk-flex uk-flex-between uk-margin-bottom uk-flex-middle"
+        class="document-title uk-flex uk-flex-between uk-margin-bottom uk-flex-top"
       >
         <span
-          class="uk-flex uk-flex-middle uk-width-1"
+          class="uk-flex uk-flex-top"
           data-test-title-container
           {{set-style cursor="text"}}
         >
-          <span>
+          <span class="uk-flex-none">
             <FaIcon
               @icon="file-alt"
               @prefix="far"
@@ -27,14 +39,14 @@
           </span>
           {{#if this.editTitle}}
             <input
-              class="uk-input uk-width-1"
+              class="uk-input"
               type="text"
               placeholder={{t "alexandria.document-details.name-placeholder"}}
               value={{@document.title}}
               data-test-title-input
               {{on "input" this.updateDocumentTitle}}
             />
-            <span>
+            <span class="uk-flex-none">
               <a
                 href="#"
                 class="uk-icon-button {{
@@ -44,11 +56,17 @@
                 data-test-save
                 {{on "click" (perform this.saveDocument)}}
               ></a>
+              <a
+                 href="#"
+                 {{on "click" (set this.editTitle false)}}
+                 class="uk-icon-button  cursor-pointer"
+                 uk-icon="icon: close"
+               ></a>
             </span>
           {{else}}
             <a
               href="#"
-              class="uk-width-1 uk-link-reset"
+              class="uk-link-reset"
               data-test-title
               {{on "click" (set this.editTitle true)}}
             >
@@ -56,12 +74,6 @@
             </a>
           {{/if}}
         </span>
-        <LinkTo
-          @query={{hash document=undefined}}
-          class="uk-icon-button"
-          uk-icon="close"
-          data-test-close
-        />
       </span>
 
       <span class="document-meta">

--- a/addon/components/document-grid.js
+++ b/addon/components/document-grid.js
@@ -10,8 +10,8 @@ export default class DocumentGridComponent extends Component {
   get selectedDocument() {
     if (this.args.selectedDocumentId) {
       return (
-        this.store.peekRecord("document", this.args.selectedDocumentId) ||
-        this.store.findRecord("document", this.args.selectedDocumentId)
+        this.documents &&
+        this.store.peekRecord("document", this.args.selectedDocumentId)
       );
     }
     return undefined;

--- a/tests/integration/components/document-details-test.js
+++ b/tests/integration/components/document-details-test.js
@@ -48,7 +48,6 @@ module("Integration | Component | document-details", function (hooks) {
     await render(hbs`<DocumentDetails @document={{this.selectedDocument}} />`);
 
     assert.dom("[data-test-file-details]").hasClass("closed");
-    assert.dom("[data-test-title-container]").hasStyle({ width: "0px" });
 
     this.set("selectedDocument", {});
 

--- a/translations/de.yaml
+++ b/translations/de.yaml
@@ -33,5 +33,6 @@ alexandria:
     no-categories: "Es wurden keine Kategorien gefunden."
 
   document-details:
+    document-title: "Dokumententitel"
     created-at: "Erstellt am {date}"
     name-placeholder: "Name..."

--- a/translations/en.yaml
+++ b/translations/en.yaml
@@ -33,5 +33,6 @@ alexandria:
     no-categories: "No categories found."
 
   document-details:
+    document-title: "Document title"
     created-at: "Created on {date}"
     name-placeholder: "Name..."


### PR DESCRIPTION
This adds a small label and fixes some issues concerning the widths
of the save and close buttons.

![Screenshot_20201115_185504](https://user-images.githubusercontent.com/65539425/99192638-24aded80-2774-11eb-833e-a33bb6a0dd2d.png)
