### PR TITLE
fix(dummy): update language to English to conform to backend

### DIFF
--- a/tests/dummy/app/routes/application.js
+++ b/tests/dummy/app/routes/application.js
@@ -5,6 +5,6 @@ export default class ApplicationRoute extends Route {
   @service intl;
 
   afterModel() {
-    this.intl.setLocale("de");
+    this.intl.setLocale("en");
   }
 }


### PR DESCRIPTION
The backend's fixtures are en English which leaves the user with
empty-string category names.