### PR TITLE
feat(document-delete-buttom): add a prompt to the delete buttons

### DIFF
--- a/addon/components/document-card.hbs
+++ b/addon/components/document-card.hbs
@@ -58,10 +58,15 @@
         <FaIcon @icon="file-download" />
         {{t "alexandria.download"}}
       </Item>
-      <Item data-test-delete {{on "click" (perform this.delete)}}>
-        <FaIcon @icon="trash-alt" @prefix="far" />
-        {{t "alexandria.delete"}}
-      </Item>
+      <DocumentDeleteButton
+        @document={{@document}}
+        as |showDialog|
+      >
+        <Item data-test-delete {{on "click" showDialog}}>
+          <FaIcon @icon="trash-alt" @prefix="far" />
+          {{t "alexandria.delete"}}
+        </Item>
+      </DocumentDeleteButton>
     </Drop>
   </div>
 </div>

--- a/addon/components/document-card.js
+++ b/addon/components/document-card.js
@@ -24,17 +24,4 @@ export default class DocumentCardComponent extends Component {
       this.notification.danger(this.intl.t("alexandria.errors.save-file"));
     }
   }
-
-  @task *delete() {
-    try {
-      yield this.args.document.destroyRecord();
-      this.notification.success(
-        this.intl.t("alexandria.success.delete-document")
-      );
-    } catch (error) {
-      this.notification.danger(
-        this.intl.t("alexandria.errors.delete-document")
-      );
-    }
-  }
 }

--- a/addon/components/document-delete-button.hbs
+++ b/addon/components/document-delete-button.hbs
@@ -1,0 +1,37 @@
+{{yield this.showDialog}}
+
+<UkModal
+  @on-hide={{this.hideDialog}}
+  @visible={{this.dialogVisible}}
+  data-test-delete-modal={{@document.id}}
+  as |Modal|
+>
+  <Modal.header>
+    <strong class="uk-modal-title">
+      {{t "alexandria.document-delete-button.prompt.title"}}
+    </strong>
+  </Modal.header>
+
+  <Modal.body>
+    <p>
+      {{t "alexandria.document-delete-button.prompt.message"
+        title=@document.title
+      }}
+    </p>
+  </Modal.body>
+
+  <Modal.footer>
+    <UkButton
+      @label={{t "alexandria.document-delete-button.prompt.cancel"}}
+      @on-click={{this.hideDialog}}
+    />
+
+    <UkButton
+      @color="primary"
+      @label={{t "alexandria.document-delete-button.prompt.confirm"}}
+      @on-click={{perform this.delete}}
+      @loading={{this.delete.isRunning}}
+      data-test-delete-confirm
+    />
+  </Modal.footer>
+</UkModal>

--- a/addon/components/document-delete-button.hbs
+++ b/addon/components/document-delete-button.hbs
@@ -21,17 +21,19 @@
   </Modal.body>
 
   <Modal.footer>
-    <UkButton
-      @label={{t "alexandria.document-delete-button.prompt.cancel"}}
-      @on-click={{this.hideDialog}}
-    />
+    <div class="uk-flex uk-flex-between">
+      <UkButton
+        @label={{t "alexandria.document-delete-button.prompt.cancel"}}
+        @on-click={{this.hideDialog}}
+      />
 
-    <UkButton
-      @color="primary"
-      @label={{t "alexandria.document-delete-button.prompt.confirm"}}
-      @on-click={{perform this.delete}}
-      @loading={{this.delete.isRunning}}
-      data-test-delete-confirm
-    />
+      <UkButton
+        @color="primary"
+        @label={{t "alexandria.document-delete-button.prompt.confirm"}}
+        @on-click={{perform this.delete}}
+        @loading={{this.delete.isRunning}}
+        data-test-delete-confirm
+      />
+    </div>
   </Modal.footer>
 </UkModal>

--- a/addon/components/document-delete-button.hbs
+++ b/addon/components/document-delete-button.hbs
@@ -3,7 +3,6 @@
 <UkModal
   @on-hide={{this.hideDialog}}
   @visible={{this.dialogVisible}}
-  data-test-delete-modal={{@document.id}}
   as |Modal|
 >
   <Modal.header>
@@ -24,7 +23,8 @@
     <div class="uk-flex uk-flex-between">
       <UkButton
         @label={{t "alexandria.document-delete-button.prompt.cancel"}}
-        @on-click={{this.hideDialog}}
+        @on-click={{this.cancel}}
+        data-test-delete-cancel={{@document.id}}
       />
 
       <UkButton
@@ -32,7 +32,7 @@
         @label={{t "alexandria.document-delete-button.prompt.confirm"}}
         @on-click={{perform this.delete}}
         @loading={{this.delete.isRunning}}
-        data-test-delete-confirm
+        data-test-delete-confirm={{@document.id}}
       />
     </div>
   </Modal.footer>

--- a/addon/components/document-delete-button.js
+++ b/addon/components/document-delete-button.js
@@ -1,0 +1,44 @@
+import { action } from "@ember/object";
+import { inject as service } from "@ember/service";
+import Component from "@glimmer/component";
+import { tracked } from "@glimmer/tracking";
+import { task } from "ember-concurrency-decorators";
+
+export default class DocumentDeleteButtonComponent extends Component {
+  @service notification;
+  @service intl;
+
+  @tracked dialogVisible = false;
+
+  @action showDialog() {
+    this.dialogVisible = true;
+  }
+
+  @action hideDialog() {
+    this.dialogVisible = false;
+
+    if (this.args.onCancel) {
+      this.args.onCancel();
+    }
+  }
+
+  @task *delete() {
+    try {
+      yield this.args.document.destroyRecord();
+
+      if (this.args.onConfirm) {
+        this.args.onConfirm(this.args.document);
+      }
+
+      this.hideDialog();
+
+      this.notification.success(
+        this.intl.t("alexandria.success.delete-document")
+      );
+    } catch (error) {
+      this.notification.danger(
+        this.intl.t("alexandria.errors.delete-document")
+      );
+    }
+  }
+}

--- a/addon/components/document-delete-button.js
+++ b/addon/components/document-delete-button.js
@@ -16,6 +16,10 @@ export default class DocumentDeleteButtonComponent extends Component {
 
   @action hideDialog() {
     this.dialogVisible = false;
+  }
+
+  @action cancel() {
+    this.hideDialog();
 
     if (this.args.onCancel) {
       this.args.onCancel();

--- a/addon/components/document-details.hbs
+++ b/addon/components/document-details.hbs
@@ -110,18 +110,21 @@
           </button>
         </div>
 
-        <LinkTo @query={{hash document=undefined}} class="uk-width-1-2">
+        <DocumentDeleteButton
+          @document={{@document}}
+          @onConfirm={{this.closePanel}}
+          as |showDialog|
+        >
           <UkButton
             data-test-delete
             @size="small"
             @color="primary"
-            class="uk-width-1 uk-button-danger"
-            @loading={{this.delete.isRunning}}
-            {{on "click" (perform this.delete)}}
+            class="uk-width-1-2 uk-button-danger"
+            {{on "click" showDialog}}
           >
             {{t "alexandria.delete"}}
           </UkButton>
-        </LinkTo>
+        </DocumentDeleteButton>
       </div>
 
       <hr />

--- a/addon/components/document-details.js
+++ b/addon/components/document-details.js
@@ -2,17 +2,22 @@ import { action } from "@ember/object";
 import { inject as service } from "@ember/service";
 import { dasherize } from "@ember/string";
 import { tracked } from "@glimmer/tracking";
-import { task, restartableTask, dropTask } from "ember-concurrency-decorators";
+import { restartableTask, dropTask } from "ember-concurrency-decorators";
 
 import DocumentCard from "./document-card";
 
 export default class DocumentDetailsComponent extends DocumentCard {
+  @service router;
+  @service store;
+
   @tracked editTitle = false;
   @tracked validTitle = true;
   @tracked availableTags;
   @tracked matchingTags;
 
-  @service store;
+  @action closePanel() {
+    this.router.transitionTo({ queryParams: { document: undefined } });
+  }
 
   @action updateDocumentTitle({ target: { value: title } }) {
     this.validTitle = Boolean(title);
@@ -22,20 +27,6 @@ export default class DocumentDetailsComponent extends DocumentCard {
   @action resetState() {
     this.editTitle = false;
     this.validTitle = true;
-  }
-
-  @task *deleteAndReset(...args) {
-    try {
-      // Cant use super.delete here since concurrency always takes the current class for perform and this causes recursion here.
-      yield this.delete.perform(...args);
-      this.notification.success(
-        this.intl.t("alexandria.success.delete-document")
-      );
-    } catch (error) {
-      this.notification.danger(
-        this.intl.t("alexandria.errors.delete-document")
-      );
-    }
   }
 
   @restartableTask *saveDocument() {

--- a/addon/components/document-details.js
+++ b/addon/components/document-details.js
@@ -2,7 +2,7 @@ import { action } from "@ember/object";
 import { inject as service } from "@ember/service";
 import { dasherize } from "@ember/string";
 import { tracked } from "@glimmer/tracking";
-import { restartableTask, dropTask } from "ember-concurrency-decorators";
+import { restartableTask, dropTask, task } from "ember-concurrency-decorators";
 
 import DocumentCard from "./document-card";
 

--- a/config/environment.js
+++ b/config/environment.js
@@ -6,6 +6,8 @@ module.exports = function (environment) {
     environment,
 
     "ember-alexandria": {},
+
+    APP: {},
   };
 
   return ENV;

--- a/config/environment.js
+++ b/config/environment.js
@@ -10,5 +10,9 @@ module.exports = function (environment) {
     APP: {},
   };
 
+  if (environment === "test") {
+    ENV.APP.rootElement = "#ember-testing";
+  }
+
   return ENV;
 };

--- a/tests/acceptance/documents-test.js
+++ b/tests/acceptance/documents-test.js
@@ -8,7 +8,7 @@ import {
 import { setupMirage } from "ember-cli-mirage/test-support";
 import { setupIntl, setLocale } from "ember-intl/test-support";
 import { setupApplicationTest } from "ember-qunit";
-import { module, test, skip } from "qunit";
+import { module, test } from "qunit";
 
 import setupRequestAssertions from "../helpers/assert-request";
 
@@ -116,7 +116,7 @@ module("Acceptance | documents", function (hooks) {
     assert.dom("[data-test-title-input]").doesNotExist();
   });
 
-  skip("document detail delete", async function (assert) {
+  test("document detail delete", async function (assert) {
     const document = this.server.create("document");
     assert.expect(5);
 
@@ -130,9 +130,7 @@ module("Acceptance | documents", function (hooks) {
       );
     });
     await click("[data-test-file-details] [data-test-delete]");
-    await click(
-      `[data-test-delete-modal="${document.id}"] [data-test-delete-submit]`
-    );
+    await click(`[data-test-delete-confirm="${document.id}"]`);
     assert.equal(currentURL(), "/", "document is removed from url");
     assert.dom("[data-test-file-details]").hasClass("closed");
     assert.dom("[data-test-document]").doesNotExist();
@@ -181,7 +179,7 @@ module("Acceptance | documents", function (hooks) {
     assert.dom("[data-test-file]").exists({ count: 1 });
   });
 
-  skip("context menu delete", async function (assert) {
+  test("context menu delete", async function (assert) {
     this.server.createList("document", 5);
     assert.expect(3);
 
@@ -197,7 +195,7 @@ module("Acceptance | documents", function (hooks) {
     await click(
       "[data-test-document]:first-child [data-test-context-menu] [data-test-delete]"
     );
-    await click('[data-test-delete-modal="1"] [data-test-delete-submit]');
+    await click('[data-test-delete-confirm="1"]');
     assert.dom("[data-test-document]").exists({ count: 4 });
   });
 });

--- a/tests/acceptance/documents-test.js
+++ b/tests/acceptance/documents-test.js
@@ -8,7 +8,7 @@ import {
 import { setupMirage } from "ember-cli-mirage/test-support";
 import { setupIntl, setLocale } from "ember-intl/test-support";
 import { setupApplicationTest } from "ember-qunit";
-import { module, test } from "qunit";
+import { module, test, skip } from "qunit";
 
 import setupRequestAssertions from "../helpers/assert-request";
 
@@ -116,7 +116,7 @@ module("Acceptance | documents", function (hooks) {
     assert.dom("[data-test-title-input]").doesNotExist();
   });
 
-  test("document detail delete", async function (assert) {
+  skip("document detail delete", async function (assert) {
     const document = this.server.create("document");
     assert.expect(5);
 
@@ -130,6 +130,9 @@ module("Acceptance | documents", function (hooks) {
       );
     });
     await click("[data-test-file-details] [data-test-delete]");
+    await click(
+      `[data-test-delete-modal="${document.id}"] [data-test-delete-submit]`
+    );
     assert.equal(currentURL(), "/", "document is removed from url");
     assert.dom("[data-test-file-details]").hasClass("closed");
     assert.dom("[data-test-document]").doesNotExist();
@@ -178,7 +181,7 @@ module("Acceptance | documents", function (hooks) {
     assert.dom("[data-test-file]").exists({ count: 1 });
   });
 
-  test("context menu delete", async function (assert) {
+  skip("context menu delete", async function (assert) {
     this.server.createList("document", 5);
     assert.expect(3);
 
@@ -194,6 +197,7 @@ module("Acceptance | documents", function (hooks) {
     await click(
       "[data-test-document]:first-child [data-test-context-menu] [data-test-delete]"
     );
+    await click('[data-test-delete-modal="1"] [data-test-delete-submit]');
     assert.dom("[data-test-document]").exists({ count: 4 });
   });
 });

--- a/tests/integration/components/document-card-test.js
+++ b/tests/integration/components/document-card-test.js
@@ -3,7 +3,7 @@ import { hbs } from "ember-cli-htmlbars";
 import engineResolverFor from "ember-engines/test-support/engine-resolver-for";
 import { setupRenderingTest } from "ember-qunit";
 import fileSaver from "file-saver";
-import { module, test } from "qunit";
+import { module, test, skip } from "qunit";
 import sinon from "sinon";
 
 const modulePrefix = "ember-alexandria";
@@ -54,14 +54,18 @@ module("Integration | Component | document-card", function (hooks) {
     );
   });
 
-  test("delete file", async function (assert) {
+  skip("delete file", async function (assert) {
     this.document = {
+      id: 1,
       destroyRecord: sinon.fake(),
     };
     await render(hbs`<DocumentCard @document={{this.document}}/>`);
 
     await click("[data-test-context-menu-trigger]");
     await click("[data-test-delete]");
+    await click(
+      `[data-test-delete-modal="${this.document.id}"] [data-test-delete-submit]`
+    );
     assert.ok(
       this.document.destroyRecord.calledOnce,
       "destroyRecord was called once"

--- a/tests/integration/components/document-card-test.js
+++ b/tests/integration/components/document-card-test.js
@@ -3,7 +3,7 @@ import { hbs } from "ember-cli-htmlbars";
 import engineResolverFor from "ember-engines/test-support/engine-resolver-for";
 import { setupRenderingTest } from "ember-qunit";
 import fileSaver from "file-saver";
-import { module, test, skip } from "qunit";
+import { module, test } from "qunit";
 import sinon from "sinon";
 
 const modulePrefix = "ember-alexandria";
@@ -54,7 +54,7 @@ module("Integration | Component | document-card", function (hooks) {
     );
   });
 
-  skip("delete file", async function (assert) {
+  test("delete file", async function (assert) {
     this.document = {
       id: 1,
       destroyRecord: sinon.fake(),
@@ -63,9 +63,7 @@ module("Integration | Component | document-card", function (hooks) {
 
     await click("[data-test-context-menu-trigger]");
     await click("[data-test-delete]");
-    await click(
-      `[data-test-delete-modal="${this.document.id}"] [data-test-delete-submit]`
-    );
+    await click(`[data-test-delete-confirm="${this.document.id}"]`);
     assert.ok(
       this.document.destroyRecord.calledOnce,
       "destroyRecord was called once"

--- a/tests/integration/components/document-delete-button-test.js
+++ b/tests/integration/components/document-delete-button-test.js
@@ -1,20 +1,30 @@
-import { render, click, waitFor } from "@ember/test-helpers";
+import { render, click } from "@ember/test-helpers";
+import setupRenderingTest from "dummy/tests/helpers/setup-rendering-test";
 import { hbs } from "ember-cli-htmlbars";
-import { setupRenderingTest } from "ember-qunit";
-import { module, skip } from "qunit";
-import sinon from "sinon";
+import { setupIntl } from "ember-intl/test-support";
+import { module, test } from "qunit";
 
 module("Integration | Component | document-delete-button", function (hooks) {
   setupRenderingTest(hooks);
+  setupIntl(hooks, "en");
 
-  skip("delete document", async function (assert) {
+  test("delete document", async function (assert) {
     this.document = {
+      id: 1,
       title: "Test",
-      destroyRecord: sinon.fake(),
+      destroyRecord() {},
     };
 
+    this.onCancel = () => assert.step("cancel");
+    this.onConfirm = () => assert.step("confirm");
+
     await render(hbs`
-      <DocumentDeleteButton @document={{this.document}} as |showDialog|>
+      <DocumentDeleteButton
+        @document={{this.document}}
+        @onConfirm={{this.onConfirm}}
+        @onCancel={{this.onCancel}}
+        as |showDialog|
+      >
         <button
           {{on "click" showDialog}}
           data-test-delete
@@ -24,12 +34,11 @@ module("Integration | Component | document-delete-button", function (hooks) {
     `);
 
     await click("[data-test-delete]");
-    await waitFor("[data-test-delete-confirm]", { timeout: 1000 });
-    await click("[data-test-delete-submit]");
+    await click("[data-test-delete-cancel]");
 
-    assert.ok(
-      this.selectedDocument.destroyRecord.calledOnce,
-      "destroyRecord was called once"
-    );
+    await click("[data-test-delete]");
+    await click("[data-test-delete-confirm]");
+
+    assert.verifySteps(["cancel", "confirm"]);
   });
 });

--- a/tests/integration/components/document-delete-button-test.js
+++ b/tests/integration/components/document-delete-button-test.js
@@ -1,0 +1,35 @@
+import { render, click, waitFor } from "@ember/test-helpers";
+import { hbs } from "ember-cli-htmlbars";
+import { setupRenderingTest } from "ember-qunit";
+import { module, skip } from "qunit";
+import sinon from "sinon";
+
+module("Integration | Component | document-delete-button", function (hooks) {
+  setupRenderingTest(hooks);
+
+  skip("delete document", async function (assert) {
+    this.document = {
+      title: "Test",
+      destroyRecord: sinon.fake(),
+    };
+
+    await render(hbs`
+      <DocumentDeleteButton @document={{this.document}} as |showDialog|>
+        <button
+          {{on "click" showDialog}}
+          data-test-delete
+          type="button"
+        >Delete</button>
+      </DocumentDeleteButton>
+    `);
+
+    await click("[data-test-delete]");
+    await waitFor("[data-test-delete-confirm]", { timeout: 1000 });
+    await click("[data-test-delete-submit]");
+
+    assert.ok(
+      this.selectedDocument.destroyRecord.calledOnce,
+      "destroyRecord was called once"
+    );
+  });
+});

--- a/tests/integration/components/document-details-test.js
+++ b/tests/integration/components/document-details-test.js
@@ -5,7 +5,7 @@ import { hbs } from "ember-cli-htmlbars";
 import { setupMirage } from "ember-cli-mirage/test-support";
 import { setupIntl } from "ember-intl/test-support";
 import fileSaver from "file-saver";
-import { module, test, skip } from "qunit";
+import { module, test } from "qunit";
 import sinon from "sinon";
 
 module("Integration | Component | document-details", function (hooks) {
@@ -80,7 +80,7 @@ module("Integration | Component | document-details", function (hooks) {
     );
   });
 
-  skip("delete document", async function (assert) {
+  test("delete document", async function (assert) {
     this.selectedDocument = {
       id: 1,
       title: "Test",
@@ -89,10 +89,7 @@ module("Integration | Component | document-details", function (hooks) {
     await render(hbs`<DocumentDetails @document={{this.selectedDocument}}/>`);
 
     await click("[data-test-delete]");
-    await click(
-      `[data-test-delete-modal="${this.selectedDocument.id}"] [data-test-delete-submit]`
-    );
-    await click("[data-test-delete-submit]");
+    await click(`[data-test-delete-confirm="${this.selectedDocument.id}"]`);
 
     assert.ok(
       this.selectedDocument.destroyRecord.calledOnce,

--- a/tests/integration/components/document-details-test.js
+++ b/tests/integration/components/document-details-test.js
@@ -5,7 +5,7 @@ import { hbs } from "ember-cli-htmlbars";
 import { setupMirage } from "ember-cli-mirage/test-support";
 import { setupIntl } from "ember-intl/test-support";
 import fileSaver from "file-saver";
-import { module, test } from "qunit";
+import { module, test, skip } from "qunit";
 import sinon from "sinon";
 
 module("Integration | Component | document-details", function (hooks) {
@@ -80,13 +80,20 @@ module("Integration | Component | document-details", function (hooks) {
     );
   });
 
-  test("delete document", async function (assert) {
+  skip("delete document", async function (assert) {
     this.selectedDocument = {
+      id: 1,
+      title: "Test",
       destroyRecord: sinon.fake(),
     };
     await render(hbs`<DocumentDetails @document={{this.selectedDocument}}/>`);
 
     await click("[data-test-delete]");
+    await click(
+      `[data-test-delete-modal="${this.selectedDocument.id}"] [data-test-delete-submit]`
+    );
+    await click("[data-test-delete-submit]");
+
     assert.ok(
       this.selectedDocument.destroyRecord.calledOnce,
       "destroyRecord was called once"

--- a/translations/de.yaml
+++ b/translations/de.yaml
@@ -33,6 +33,13 @@ alexandria:
   document-upload-button:
     no-categories: "Es wurden keine Kategorien gefunden."
 
+  document-delete-button:
+    prompt:
+      title: "Dokument löschen"
+      message: "Wollen Sie das Dokument \"{title}\" wirklich mit seiner ganzen Geschichte löschen?"
+      cancel: "Abbrechen"
+      confirm: "Löschen"
+
   document-details:
     document-title: "Dokumententitel"
     created-at: "Erstellt am {date}"

--- a/translations/en.yaml
+++ b/translations/en.yaml
@@ -33,6 +33,13 @@ alexandria:
   document-upload-button:
     no-categories: "No categories found."
 
+  document-delete-button:
+    prompt:
+      title: "Delete document"
+      message: "Do you really want to delete the document \"{title}\" and its complete history?"
+      cancel: "Cancel"
+      confirm: "Delete"
+
   document-details:
     document-title: "Document title"
     created-at: "Created on {date}"


### PR DESCRIPTION
This adds a component that provides a prompt and handles deletion.

I had to disable quite a few tests. I updated the tests but there is a problem with where ember-uikit places its modal dialogues. I tried using the master branch as there is a relevant update that hasn't been released but that didn't seem to make a difference.