### PR TITLE
fix(document-details): reset matching tags and minor fixes

### DIFF
--- a/addon/components/document-details.hbs
+++ b/addon/components/document-details.hbs
@@ -159,7 +159,7 @@
 
           <div class="uk-accordion-content">
             {{#if @document.tags.length}}
-              <div class="uk-margin-top uk-margin-bottom">
+              <div class="uk-margin-bottom">
                 {{#each @document.tags as |tag|}}
                   <span class="uk-badge">
                     {{tag.name}}

--- a/addon/components/document-details.js
+++ b/addon/components/document-details.js
@@ -83,13 +83,13 @@ export default class DocumentDetailsComponent extends DocumentCard {
   }
 
   @action onSearchTag() {
-    if (!this.availableTags) {
-      return [];
+    if (!this.availableTags || this.tagSearchBox.value === "") {
+      this.matchingTags = [];
+    } else {
+      this.matchingTags = this.availableTags.filter((tag) =>
+        tag.name.toLowerCase().startsWith(this.tagSearchBox.value.toLowerCase())
+      );
     }
-
-    this.matchingTags = this.availableTags.filter((tag) =>
-      tag.name.toLowerCase().startsWith(this.tagSearchBox.value.toLowerCase())
-    );
   }
 
   @task *addTagSuggestion(tag) {
@@ -116,6 +116,13 @@ export default class DocumentDetailsComponent extends DocumentCard {
     const existing = this.availableTags.findBy("name", tag);
     const attached = this.args.document.tags;
 
+    this.tagSearchBox.value = "";
+    this.matchingTags = [];
+
+    if (attached.findBy("name", tag)) {
+      return;
+    }
+
     if (existing) {
       attached.pushObject(existing);
     } else {
@@ -129,9 +136,6 @@ export default class DocumentDetailsComponent extends DocumentCard {
     }
 
     yield this.args.document.save();
-
-    this.tagSearchBox.value = "";
-    this.matchingTags = [];
   }
 
   @task *removeTag(tag) {


### PR DESCRIPTION
This change resets the matching tags when the search box is empty
and after adding a tag to the document. This also removes unneeded
queries when a tag already exists on the document and updates the
styling of the selected tags.

![Screenshot_20201119_162743](https://user-images.githubusercontent.com/65539425/99686763-33521880-2a84-11eb-8ca9-1fb44fa1144b.png)
