### PR TITLE
fix(deps): pin ember-uikit to 2.2.0 to fix floating test issue with modal and rootElement

### DIFF
--- a/package.json
+++ b/package.json
@@ -47,7 +47,7 @@
     "ember-moment": "^8.0.1",
     "ember-simple-set-helper": "^0.1.2",
     "ember-truth-helpers": "^2.1.0",
-    "ember-uikit": "^2.2.0",
+    "ember-uikit": "2.2.0",
     "file-saver": "^2.0.5"
   },
   "devDependencies": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -7226,7 +7226,7 @@ ember-try@1.4.0:
     rsvp "^4.7.0"
     walk-sync "^1.1.3"
 
-ember-uikit@^2.2.0:
+ember-uikit@2.2.0:
   version "2.2.0"
   resolved "https://registry.yarnpkg.com/ember-uikit/-/ember-uikit-2.2.0.tgz#f62d24cb55a1ea6aedc37e94b73f9f29c52a9342"
   integrity sha512-+nSFmCt2zQLdCj8t39fcwOBavMRepUNvGKKR8vwtnszHCdKsRwo3rdKy8Im87pMKtR/LhUHh9BhbpyatsTzkYA==


### PR DESCRIPTION
The modal is not rendered in the rootElement specified in the config anymore. This causes css selectors to fail.