### PR TITLE
fix(app): export tag serializer to and remove hard-coded value

### DIFF
--- a/addon/components/document-details.js
+++ b/addon/components/document-details.js
@@ -119,7 +119,7 @@ export default class DocumentDetailsComponent extends DocumentCard {
     } else {
       const fresh = this.store.createRecord("tag");
       fresh.id = dasherize(tag);
-      fresh.name = { en: tag };
+      fresh.name = tag;
 
       yield fresh.save();
 

--- a/app/serializers/tag.js
+++ b/app/serializers/tag.js
@@ -1,0 +1,1 @@
+export { default } from "ember-alexandria/serializers/tag";


### PR DESCRIPTION
Without the export the projects would have to provide their own
serializers for the tags. Plus, the language was hard-coded.