### PR TITLE
feat(models): change tag name to non-localized

### DIFF
--- a/addon/models/tag.js
+++ b/addon/models/tag.js
@@ -2,7 +2,7 @@ import { attr, hasMany } from "@ember-data/model";
 import { LocalizedModel, localizedAttr } from "ember-localized-model";
 
 export default class TagModel extends LocalizedModel {
-  @localizedAttr name;
+  @attr name;
   @localizedAttr description;
   @attr meta;
 


### PR DESCRIPTION
Localization doesn't really work in practice as there is no central tag administration that could deal with missing translations.

See https://github.com/projectcaluma/alexandria/pull/117