### PR TITLE
refactor(document-details): reuse new close action with button

### DIFF
--- a/addon/components/document-details.hbs
+++ b/addon/components/document-details.hbs
@@ -12,12 +12,13 @@
         <div class="uk-text-meta">
           {{t "alexandria.document-details.document-title"}}
         </div>
-        <LinkTo
-          @query={{hash document=undefined}}
+        <button
           class="uk-icon-button uk-flex-none"
+          type="button"
           uk-icon="close"
           data-test-close
-        />
+          {{on "click" this.closePanel}}
+        ></button>
       </div>
 
       <span


### PR DESCRIPTION
Using a link for close buttons is wrong anyway and I'd already created
the closePanel action to pass to the DeleteButton component.