### PR TITLE
fix(document-upload-button): update multiple attribute

### DIFF
--- a/.ember-cli
+++ b/.ember-cli
@@ -1,9 +1,3 @@
 {
-  /**
-    Ember CLI sends analytics information by default. The data is completely
-    anonymous, but there are times when you might want to disable this behavior.
-
-    Setting `disableAnalytics` to true will prevent any data from being sent.
-  */
   "disableAnalytics": false
 }

--- a/addon/components/document-upload-button.hbs
+++ b/addon/components/document-upload-button.hbs
@@ -18,7 +18,7 @@
   {{#if @category}}
     <input
       type="file"
-      multiple
+      multiple="multiple"
       data-test-input
       {{on "change" (perform this.upload @category)}}
     />
@@ -28,7 +28,7 @@
         <Item uk-form-custom data-test-upload-category>
           <input
             type="file"
-            multiple
+            multiple="multiple"
             data-test-input
             {{on "change" (perform this.upload category)}}
           />


### PR DESCRIPTION
This changes the boolean attribute to the old-school/legacy notation
as the normal style doesn't seem to hold when importing the engine
in an Ember application.