### PR TITLE
refactor(tags): move tag handling to service

### DIFF
--- a/addon/components/document-details.hbs
+++ b/addon/components/document-details.hbs
@@ -155,7 +155,7 @@
           </div>
         </li>
 
-        <li>
+        <li class="uk-open">
           <a class="uk-accordion-title" href="#">
             {{t "alexandria.document-details.tags.title"}}
           </a>

--- a/addon/components/document-details.js
+++ b/addon/components/document-details.js
@@ -1,6 +1,5 @@
 import { action } from "@ember/object";
 import { inject as service } from "@ember/service";
-import { dasherize } from "@ember/string";
 import { tracked } from "@glimmer/tracking";
 import { restartableTask, dropTask, task } from "ember-concurrency-decorators";
 
@@ -8,13 +7,12 @@ import DocumentCard from "./document-card";
 
 export default class DocumentDetailsComponent extends DocumentCard {
   @service router;
-  @service store;
   @service documents;
+  @service tags;
 
   @tracked editTitle = false;
   @tracked validTitle = true;
-  @tracked availableTags;
-  @tracked matchingTags;
+  @tracked matchingTags = [];
 
   @action closePanel() {
     this.router.transitionTo({ queryParams: { document: undefined } });
@@ -51,72 +49,42 @@ export default class DocumentDetailsComponent extends DocumentCard {
     }
   }
 
+  // Tags
+
   @action async didInsertTagSearch(element) {
     this.tagSearchBox = element.querySelector("input");
-
-    const allTags = await this.store.findAll("tag");
-    this.availableTags = allTags.rejectBy("name", undefined);
+    await this.tags.fetchAllTags.perform();
   }
 
   @action onSearchTag() {
-    if (!this.availableTags || this.tagSearchBox.value === "") {
+    if (!this.tags.allTags || this.tagSearchBox.value === "") {
       this.matchingTags = [];
     } else {
       const searchValue = this.tagSearchBox.value.toLowerCase();
-      this.matchingTags = this.availableTags.filter((tag) =>
+      this.matchingTags = this.tags.allTags.filter((tag) =>
         tag.name.toLowerCase().startsWith(searchValue)
       );
     }
   }
 
   @task *addTagSuggestion(tag) {
-    const { tags } = this.args.document;
+    yield this.tags.add(this.args.document, tag);
 
     this.tagSearchBox.value = "";
     this.matchingTags = [];
-
-    if (tags.findBy("id", tag.id)) {
-      return;
-    }
-
-    tags.pushObject(tag);
-
-    yield this.args.document.save();
   }
 
   @task *addTagFromForm(event) {
     event.preventDefault();
 
-    const form = event.target;
-    const tag = form.elements.tag.value;
-
-    const existing = this.availableTags.findBy("name", tag);
-    const attached = this.args.document.tags;
+    const tag = event.target.elements.tag.value;
+    yield this.tags.add(this.args.document, tag);
 
     this.tagSearchBox.value = "";
     this.matchingTags = [];
-
-    if (attached.findBy("name", tag)) {
-      return;
-    }
-
-    if (existing) {
-      attached.pushObject(existing);
-    } else {
-      const fresh = this.store.createRecord("tag");
-      fresh.id = dasherize(tag);
-      fresh.name = tag;
-
-      yield fresh.save();
-
-      attached.pushObject(fresh);
-    }
-
-    yield this.args.document.save();
   }
 
   @task *removeTag(tag) {
-    this.args.document.tags.removeObject(tag);
-    yield this.args.document.save();
+    yield this.tags.remove(this.args.document, tag);
   }
 }

--- a/addon/components/document-grid.hbs
+++ b/addon/components/document-grid.hbs
@@ -10,7 +10,7 @@
       />
 
       <TagFilter
-        @filters={{hash withDocumentsInCategory=@filters.category}}
+        @category={{@filters.category}}
         @selectedTags={{@filters.tags}}
         class="uk-margin-left"
       />

--- a/addon/components/tag-filter.hbs
+++ b/addon/components/tag-filter.hbs
@@ -1,14 +1,14 @@
 <div
   class="uk-border uk-padding-small uk-width-expand"
   ...attributes
-  {{did-insert (perform this.fetchTags)}}
-  {{did-update (perform this.fetchTags) @filters}}
+  {{did-insert this.onInsert}}
+  {{did-update this.onInsert @category}}
 >
-  {{#each this.tags as |tag|}}
+  {{#each this.tags.searchTags as |tag|}}
     <button
       type="button"
       class="uk-badge uk-border-remove {{
-        if (contains tag.id this.selectedTagsArray) "uk-background-secondary"
+        if (includes tag.id this.selectedTagsArray) "uk-background-secondary"
       }}"
       {{on "click" (fn this.toggleTag tag)}}
     >

--- a/addon/components/tag-filter.js
+++ b/addon/components/tag-filter.js
@@ -1,29 +1,24 @@
 import { action } from "@ember/object";
 import { inject as service } from "@ember/service";
 import Component from "@glimmer/component";
-import { lastValue, task } from "ember-concurrency-decorators";
 
 export default class TagFilterComponent extends Component {
-  @service store;
   @service router;
-
-  @lastValue("fetchTags") tags;
+  @service tags;
 
   get selectedTagsArray() {
+    // Selected tags come directly from the query parameter and are strings.
     return typeof this.args.selectedTags === "string"
       ? this.args.selectedTags.split(",")
       : [];
   }
 
-  @task
-  *fetchTags() {
-    return yield this.store.query("tag", {
-      filter: this.args.filters,
-    });
+  @action onInsert() {
+    this.tags.category = this.args.category;
+    this.tags.fetchSearchTags.perform();
   }
 
-  @action
-  toggleTag(tag) {
+  @action toggleTag(tag) {
     let tags;
 
     if (this.selectedTagsArray.includes(tag.id)) {

--- a/addon/services/tags.js
+++ b/addon/services/tags.js
@@ -1,0 +1,83 @@
+import { action } from "@ember/object";
+import Service, { inject as service } from "@ember/service";
+import { dasherize } from "@ember/string";
+import { tracked } from "@glimmer/tracking";
+import { lastValue, task } from "ember-concurrency-decorators";
+
+export default class TagsService extends Service {
+  @service store;
+
+  /**
+   * Different parts of the application should be able to update the searchTags
+   * list as easily as possible. By setting the category on the service the
+   * triggering code doesn't need to find the correct query parameter.
+   */
+  @tracked category = null;
+
+  /**
+   * This list is a stop-gap measure for the type-ahead search
+   * until the API implements a search field. (STARTSWITH)
+   */
+  @lastValue("fetchAllTags") allTags;
+  /** The searchTags are used in the TagFilter component. */
+  @lastValue("fetchSearchTags") searchTags;
+
+  @task *fetchAllTags() {
+    return yield this.store.findAll("tag");
+  }
+
+  @task *fetchSearchTags() {
+    return yield this.store.query("tag", {
+      filter: { withDocumentsInCategory: this.category },
+    });
+  }
+
+  /**
+   * Adds a tag to a document and creates the tag if necessary.
+   *
+   * @param {Object} document The target document.
+   * @param {Object|String} tag Either e tag instance or a name.
+   */
+  @action async add(document, tag) {
+    if (typeof tag === "string") {
+      const existing = this.allTags.findBy("name", tag);
+
+      if (existing) {
+        tag = existing;
+      } else {
+        tag = this.store.createRecord("tag", {
+          id: dasherize(tag),
+          name: tag,
+        });
+        await tag.save();
+      }
+    }
+
+    if (document.tags.findBy("id", tag.id)) {
+      return;
+    }
+
+    document.tags.pushObject(tag);
+    await document.save();
+
+    this.fetchAllTags.perform();
+    this.fetchSearchTags.perform();
+  }
+
+  /**
+   * Removes a tag from a document.
+   *
+   * @param {Object} document The target document.
+   * @param {Object|String} tag Either e tag instance or a name.
+   */
+  @action async remove(document, tag) {
+    if (typeof tag === "string") {
+      tag = this.allTags.findBy("name", tag);
+    }
+
+    document.tags.removeObject(tag);
+    await document.save();
+
+    this.fetchSearchTags.perform();
+  }
+}

--- a/app/services/tags.js
+++ b/app/services/tags.js
@@ -1,0 +1,1 @@
+export { default } from "ember-alexandria/services/tags";

--- a/tests/dummy/mirage/factories/tag.js
+++ b/tests/dummy/mirage/factories/tag.js
@@ -4,6 +4,6 @@ import faker from "faker";
 import { setAllLocales } from "./helpers";
 
 export default Factory.extend({
-  name: () => setAllLocales(faker.lorem.word()),
+  name: () => faker.lorem.word(),
   description: () => setAllLocales(faker.lorem.sentence()),
 });

--- a/tests/unit/services/tags-test.js
+++ b/tests/unit/services/tags-test.js
@@ -1,0 +1,95 @@
+import { setupMirage } from "ember-cli-mirage/test-support";
+import { setupTest } from "ember-qunit";
+import { module, test } from "qunit";
+
+module("Unit | Service | tags", function (hooks) {
+  setupTest(hooks);
+  setupMirage(hooks);
+
+  test("it exists", function (assert) {
+    const service = this.owner.lookup("service:tags");
+    assert.ok(service);
+  });
+
+  test("it adds existing tags", async function (assert) {
+    const requests = this.server.pretender.handledRequests;
+
+    const service = this.owner.lookup("service:tags");
+    const store = this.owner.lookup("service:store");
+
+    await service.fetchAllTags.perform();
+
+    const document = await store.createRecord("document").save();
+    const tag = await store.createRecord("tag", { name: "T1" }).save();
+
+    await service.add(document, tag);
+
+    assert.deepEqual(
+      requests.map((request) => request.method),
+      [
+        "GET", // fetchAllTags
+        "POST", // Create document
+        "POST", // Create tag
+        "PATCH", // Add tag to document
+        "GET", // fetchAllTags
+        "GET", // fetchSearchTags
+      ]
+    );
+
+    assert.ok(document.tags.includes(tag));
+  });
+
+  test("it adds new tags", async function (assert) {
+    const requests = this.server.pretender.handledRequests;
+
+    const service = this.owner.lookup("service:tags");
+    const store = this.owner.lookup("service:store");
+
+    await service.fetchAllTags.perform();
+
+    const document = await store.createRecord("document").save();
+    const tag = "T1";
+
+    await service.add(document, tag);
+
+    assert.deepEqual(
+      requests.map((request) => request.method),
+      [
+        "GET", // fetchAllTags
+        "POST", // Create document
+        "POST", // Create tag
+        "PATCH", // Add tag to document
+        "GET", // fetchAllTags
+        "GET", // fetchSearchTags
+      ]
+    );
+
+    assert.ok(document.tags.findBy("name", tag));
+  });
+
+  test("it removes tags", async function (assert) {
+    const requests = this.server.pretender.handledRequests;
+
+    const service = this.owner.lookup("service:tags");
+    const store = this.owner.lookup("service:store");
+
+    await service.fetchAllTags.perform();
+
+    const document = await store.createRecord("document").save();
+    const tag = document.tags.firstObject;
+
+    await service.remove(document, tag);
+
+    assert.deepEqual(
+      requests.map((request) => request.method),
+      [
+        "GET", // fetchAllTags
+        "POST", // Create document
+        "PATCH", // Remove tag from document
+        "GET", // fetchSearchTags
+      ]
+    );
+
+    assert.notOk(document.tags.includes(tag));
+  });
+});


### PR DESCRIPTION
This allows for all the components to work on a shared instance.
Currently, we cannot update the tags in the TagFilter when adding
a new tag in the DocumentDetail.