### PR TITLE
feat(document-grid): show a warning when files cannot be dropped

### DIFF
--- a/addon/components/document-grid.hbs
+++ b/addon/components/document-grid.hbs
@@ -17,9 +17,11 @@
     </div>
 
     <div
-      class="uk-position-relative uk-height-1-1 {{
-        if this.isDragOver "document-grid--dragover"
-      }}"
+      class="
+      uk-position-relative uk-height-1-1
+      {{if this.isDragOver "document-grid--dragover"}}
+       {{unless this.canDrop "document-grid--disallowed"}}
+      "
       {{on "dragenter" this.onDragEnter}}
       {{on "dragleave" this.onDragLeave}}
       {{on "dragover" this.onDragOver}}
@@ -76,7 +78,11 @@
           class="uk-width-1 uk-padding-remove uk-position-bottom uk-button uk-button-primary"
           type="button"
         >
-          {{t "alexandria.document-grid.drop-to-upload"}}
+          {{if
+            this.canDrop
+            (t "alexandria.document-grid.drop-to-upload")
+            (t "alexandria.document-grid.drop-not-allowed")
+          }}
         </button>
       {{/if}}
     </div>

--- a/addon/components/document-grid.js
+++ b/addon/components/document-grid.js
@@ -15,6 +15,10 @@ export default class DocumentGridComponent extends Component {
   @tracked isDragOver = false;
   @tracked dragCounter = 0;
 
+  get canDrop() {
+    return Boolean(this.args.filters && this.args.filters.category);
+  }
+
   get selectedDocument() {
     if (this.args.selectedDocumentId) {
       return (
@@ -55,19 +59,11 @@ export default class DocumentGridComponent extends Component {
   // Drag'n'Drop document upload
 
   @action onDragEnter() {
-    if (!this.args.filters.category) {
-      return;
-    }
-
     this.dragCounter++;
     this.isDragOver = true;
   }
 
   @action onDragLeave() {
-    if (!this.args.filters.category) {
-      return;
-    }
-
     this.dragCounter--;
     this.isDragOver = this.dragCounter > 0;
   }

--- a/app/styles/components/_document-grid.scss
+++ b/app/styles/components/_document-grid.scss
@@ -15,4 +15,12 @@
   &--dragover {
     border: 1px solid uikit.$alert-primary-color;
   }
+
+  &--disallowed {
+    border-color: uikit.$alert-danger-color;
+
+    & > button {
+      background-color: uikit.$alert-danger-color;
+    }
+  }
 }

--- a/translations/de.yaml
+++ b/translations/de.yaml
@@ -42,6 +42,7 @@ alexandria:
 
   document-grid:
     drop-to-upload: "Datei fallen lassen, um sie hochzuladen"
+    drop-not-allowed: "Keine Kategorie ausgewählt"
 
   document-details:
     document-title: "Dokumententitel"

--- a/translations/en.yaml
+++ b/translations/en.yaml
@@ -42,6 +42,7 @@ alexandria:
 
   document-grid:
     drop-to-upload: "Drop file to upload"
+    drop-not-allowed: "No category selected"
 
   document-details:
     document-title: "Document title"


### PR DESCRIPTION
Documents can only be uploaded if a category is selected. This colors
the UI feedback in red and changes the text if no category is selected.