### PR TITLE
feat: introduce created-by to documents, files, and tags

### DIFF
--- a/addon/controllers/application.js
+++ b/addon/controllers/application.js
@@ -3,7 +3,7 @@ import { inject as service } from "@ember/service";
 import { tracked } from "@glimmer/tracking";
 
 export default class ApplicationController extends Controller {
-  queryParams = ["category", "tags", "search", "document"];
+  queryParams = ["category", "tags", "search", "document", "activeGroup"];
 
   @service config;
 
@@ -12,12 +12,14 @@ export default class ApplicationController extends Controller {
   @tracked tags;
   @tracked search;
   @tracked document;
+  @tracked activeGroup;
 
   get documentFilters() {
     let filters = {
       category: this.category,
       tags: this.tags,
       search: this.search,
+      activeGroup: this.activeGroup,
     };
 
     if (this.config && this.config.modelMetaFilters.document) {

--- a/addon/models/document.js
+++ b/addon/models/document.js
@@ -4,10 +4,14 @@ import { LocalizedModel, localizedAttr } from "ember-localized-model";
 export default class DocumentModel extends LocalizedModel {
   @localizedAttr title;
   @localizedAttr description;
+  @attr meta;
+
   @attr createdAt;
   @attr createdByUser;
   @attr createdByGroup;
-  @attr meta;
+  @attr modifiedAt;
+  @attr modifiedByUser;
+  @attr modifiedByGroup;
 
   @belongsTo category;
   @hasMany tags;

--- a/addon/models/file.js
+++ b/addon/models/file.js
@@ -7,8 +7,13 @@ export default class FileModel extends Model {
   @attr downloadUrl;
   @attr objectName;
   @attr meta;
+
   @attr createdAt;
   @attr createdByUser;
+  @attr createdByGroup;
+  @attr modifiedAt;
+  @attr modifiedByUser;
+  @attr modifiedByGroup;
 
   @belongsTo document;
 

--- a/addon/models/tag.js
+++ b/addon/models/tag.js
@@ -6,5 +6,12 @@ export default class TagModel extends LocalizedModel {
   @localizedAttr description;
   @attr meta;
 
+  @attr createdAt;
+  @attr createdByUser;
+  @attr createdByGroup;
+  @attr modifiedAt;
+  @attr modifiedByUser;
+  @attr modifiedByGroup;
+
   @hasMany documents;
 }

--- a/addon/routes/application.js
+++ b/addon/routes/application.js
@@ -4,7 +4,8 @@ import { inject as service } from "@ember/service";
 export default class ApplicationRoute extends Route {
   @service config;
 
-  model(_, transition) {
+  model(params, transition) {
     this.config.alexandriaQueryParams = transition.to.parent.params;
+    this.config.activeGroup = params.activeGroup;
   }
 }

--- a/addon/services/config.js
+++ b/addon/services/config.js
@@ -4,13 +4,21 @@ import { tracked } from "@glimmer/tracking";
 export default class ConfigService extends Service {
   @tracked alexandriaQueryParams = {};
 
-  /* Defaults so we can lookup
+  /**
+   * The active group is used for the createdByGroup property when creating new
+   * documents and files. This is important as a user can be in multiple groups.
+   */
+  @tracked activeGroup = null;
+
+  /**
+   * Defaults so we can lookup
    * `this.config.modelMetaFilters.document`
    * without an exeption on modelMetaFilters.
    */
   get modelMetaFilters() {
     return {};
   }
+
   get defaultModelMeta() {
     return {};
   }

--- a/addon/services/documents.js
+++ b/addon/services/documents.js
@@ -24,6 +24,8 @@ export default class DocumentsService extends Service {
         const documentModel = this.store.createRecord("document", {
           category,
           meta: this.config.defaultModelMeta.document,
+          createdByGroup: this.config.activeGroup,
+          modifiedByGroup: this.config.activeGroup,
         });
         documentModel.title = file.name;
         await documentModel.save();
@@ -32,6 +34,8 @@ export default class DocumentsService extends Service {
           name: file.name,
           type: "original",
           document: documentModel,
+          createdByGroup: this.config.activeGroup,
+          modifiedByGroup: this.config.activeGroup,
         });
         await fileModel.save();
 
@@ -58,6 +62,8 @@ export default class DocumentsService extends Service {
       name: file.name,
       type: "original",
       document,
+      createdByGroup: this.config.activeGroup,
+      modifiedByGroup: this.config.activeGroup,
     });
 
     await fileModel.save();

--- a/addon/services/tags.js
+++ b/addon/services/tags.js
@@ -6,6 +6,7 @@ import { lastValue, task } from "ember-concurrency-decorators";
 
 export default class TagsService extends Service {
   @service store;
+  @service config;
 
   /**
    * Different parts of the application should be able to update the searchTags
@@ -19,6 +20,7 @@ export default class TagsService extends Service {
    * until the API implements a search field. (STARTSWITH)
    */
   @lastValue("fetchAllTags") allTags;
+
   /** The searchTags are used in the TagFilter component. */
   @lastValue("fetchSearchTags") searchTags;
 
@@ -48,6 +50,8 @@ export default class TagsService extends Service {
         tag = this.store.createRecord("tag", {
           id: dasherize(tag),
           name: tag,
+          createdByGroup: this.config.activeGroup,
+          modifiedByGroup: this.config.activeGroup,
         });
         await tag.save();
       }

--- a/tests/dummy/app/adapters/application.js
+++ b/tests/dummy/app/adapters/application.js
@@ -2,4 +2,12 @@ import JSONAPIAdapter from "@ember-data/adapter/json-api";
 
 export default class ApplicationAdapter extends JSONAPIAdapter {
   namespace = "api/v1";
+
+  headers = {
+    // This requires two environment variables to be set on the backend:
+    // https://github.com/projectcaluma/alexandria#configuration
+    // - OIDC_AUTH_BACKEND=alexandria.oidc_auth.authentication.DummyAuthenticationBackend
+    // - DEBUG=true
+    Authorization: "Bearer DUMMY",
+  };
 }

--- a/tests/dummy/app/templates/application.hbs
+++ b/tests/dummy/app/templates/application.hbs
@@ -20,6 +20,22 @@
         </li>
       </ul>
     </div>
+
+    <div class="uk-navbar-right">
+      <ul class="uk-navbar-nav">
+        <li>
+          <LinkTo @query={{hash activeGroup="dev-group"}}>
+            dev-group
+          </LinkTo>
+        </li>
+
+        <li>
+          <LinkTo @query={{hash activeGroup="secondary-group"}}>
+            secondary-group
+          </LinkTo>
+        </li>
+      </ul>
+    </div>
   </nav>
 
   <main class="uk-height-1-1 uk-overflow-auto">

--- a/tests/dummy/mirage/factories/document.js
+++ b/tests/dummy/mirage/factories/document.js
@@ -6,8 +6,8 @@ import { setAllLocales } from "./helpers";
 export default Factory.extend({
   title: () => setAllLocales(faker.commerce.product()),
   description: () => setAllLocales(faker.company.catchPhrase()),
-  createdByUser: () => `${faker.name.firstName()} ${faker.name.lastName()}`,
-  createdByGroup: () => faker.company.companyName(),
+  createdByUser: "dummy",
+  createdByGroup: "dummy-group",
   createdAt: () => faker.date.past(),
   thumbnail: null,
 

--- a/tests/dummy/mirage/factories/file.js
+++ b/tests/dummy/mirage/factories/file.js
@@ -2,7 +2,8 @@ import { Factory } from "ember-cli-mirage";
 import faker from "faker";
 
 export default Factory.extend({
-  createdByGroup: () => faker.company.companyName(),
+  createdByUser: "dummy",
+  createdByGroup: "dummy-group",
   createdAt: () => faker.date.past(),
   name: () => faker.lorem.word(),
   type: "original",

--- a/tests/dummy/mirage/factories/tag.js
+++ b/tests/dummy/mirage/factories/tag.js
@@ -6,4 +6,6 @@ import { setAllLocales } from "./helpers";
 export default Factory.extend({
   name: () => faker.lorem.word(),
   description: () => setAllLocales(faker.lorem.sentence()),
+  createdByUser: "dummy",
+  createdByGroup: "dummy-group",
 });

--- a/tests/unit/controllers/application-test.js
+++ b/tests/unit/controllers/application-test.js
@@ -11,6 +11,7 @@ module("Unit | Controller | application", function (hooks) {
 
   test("compute document filters", function (assert) {
     const controller = this.owner.lookup("controller:application");
+    controller.activeGroup = "group";
     controller.search = "test";
     controller.category = 1;
     controller.config = {
@@ -20,6 +21,7 @@ module("Unit | Controller | application", function (hooks) {
     };
 
     assert.deepEqual(controller.documentFilters, {
+      activeGroup: "group",
       category: 1,
       meta: JSON.stringify([{ key: "instance_id", value: "1" }]),
       search: "test",


### PR DESCRIPTION
As a user can be in multiple groups we need a way to choose which
group will be used for created-by (and modified-by). Plus, we only
fetch the documents with a matching created-by value.