### PR TITLE
fix: temporarily disable the ember-release test

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -59,7 +59,9 @@ jobs:
       matrix:
         scenario:
           - ember-lts-3.16
-          - ember-release
+          # There is a bug upstream that breaks Ember Engine.
+          # https://github.com/ember-engines/ember-engines/issues/740
+          # - ember-release
 
     steps:
       - uses: actions/checkout@v2


### PR DESCRIPTION
There is a bug upstream that breaks Ember Engine. As I didn't
find a way to work around this bug we decided to disable the
test for now.