### PR TITLE
feat(document-details): add form to edit the document's description

### DIFF
--- a/addon/components/document-details.hbs
+++ b/addon/components/document-details.hbs
@@ -77,6 +77,49 @@
         </span>
       </span>
 
+      <p class="uk-flex">
+        {{#if this.editDescription}}
+          <textarea
+            class="uk-textarea"
+            {{on "input" this.updateDocumentDescription}}
+          >
+            {{~@document.description~}}
+          </textarea>
+          <div class="uk-flex uk-flex-column">
+            <a
+              class="uk-icon-button cursor-pointer"
+              href="#"
+              uk-icon="icon: check"
+              {{on "click" (perform this.saveDocument)}}
+            ></a>
+            <a
+              href="#"
+              class="uk-icon-button cursor-pointer"
+              uk-icon="icon: close"
+              {{on "click" (set this.editDescription false)}}
+            ></a>
+          </div>
+        {{else}}
+          {{#if @document.description}}
+            <a
+              class="uk-link-reset"
+              href="#"
+              {{on "click" (set this.editDescription true)}}
+            >
+              {{@document.description}}
+            </a>
+          {{else}}
+            <a
+              class="uk-link-reset"
+              href="#"
+              {{on "click" (set this.editDescription true)}}
+            >
+              {{t "alexandria.document-details.add-description"}}
+            </a>
+          {{/if}}
+        {{/if}}
+      </p>
+
       <span class="document-meta">
         <p data-test-created-at>
           {{t

--- a/addon/components/document-details.js
+++ b/addon/components/document-details.js
@@ -11,6 +11,7 @@ export default class DocumentDetailsComponent extends DocumentCard {
   @service tags;
 
   @tracked editTitle = false;
+  @tracked editDescription = false;
   @tracked validTitle = true;
   @tracked matchingTags = [];
 
@@ -23,15 +24,20 @@ export default class DocumentDetailsComponent extends DocumentCard {
     this.args.document.title = title;
   }
 
+  @action updateDocumentDescription({ target: { value: description } }) {
+    this.args.document.description = description;
+  }
+
   @action resetState() {
     this.editTitle = false;
     this.validTitle = true;
+    this.editDescription = false;
   }
 
   @restartableTask *saveDocument() {
     try {
       yield this.args.document.save();
-      this.editTitle = false;
+      this.resetState();
       this.notification.success(this.intl.t("alexandria.success.update"));
     } catch (error) {
       this.notification.danger(this.intl.t("alexandria.errors.update"));

--- a/translations/de.yaml
+++ b/translations/de.yaml
@@ -49,6 +49,7 @@ alexandria:
     created-at: "Erstellt am {date}"
     name-placeholder: "Name..."
     version-history: "Versionsgeschichte"
+    add-description: "Beschreibung hinzufügen"
     replace: "Ersetzen"
     tags:
       title: "Tags"

--- a/translations/en.yaml
+++ b/translations/en.yaml
@@ -49,6 +49,7 @@ alexandria:
     created-at: "Created on {date}"
     name-placeholder: "Name..."
     version-history: "Version history"
+    add-description: "Add description"
     replace: "Replace"
     tags:
       title: "Tags"


### PR DESCRIPTION
This uses the same idea/logic as the title edit form.

![Screenshot_20210114_151149](https://user-images.githubusercontent.com/65539425/104602016-3bd96080-567b-11eb-848b-30447d0f53cc.png)

![Screenshot_20210114_151340](https://user-images.githubusercontent.com/65539425/104602032-3e3bba80-567b-11eb-9d9f-7cc4eeae23f8.png)

![Screenshot_20210114_151416](https://user-images.githubusercontent.com/65539425/104602038-40057e00-567b-11eb-94a9-bb0c6647a64b.png)
