### PR TITLE
fix: reenable the ember-release test

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -59,9 +59,7 @@ jobs:
       matrix:
         scenario:
           - ember-lts-3.16
-          # There is a bug upstream that breaks Ember Engine.
-          # https://github.com/ember-engines/ember-engines/issues/740
-          # - ember-release
+          - ember-release
 
     steps:
       - uses: actions/checkout@v2


### PR DESCRIPTION
This reverts PR #187 as they have fixed the problem upstream.
https://github.com/ember-engines/ember-engines/releases/tag/v0.8.9