### PR TITLE
feat(document-details): update UI for description and its form

### DIFF
--- a/addon/components/document-details.hbs
+++ b/addon/components/document-details.hbs
@@ -9,9 +9,9 @@
   <div class="uk-overflow-auto">
     <div class="uk-padding-small">
       <div class="uk-flex uk-flex-between uk-flex-bottom">
-        <div class="uk-text-meta">
+        <label class="uk-text-meta" for="alexandria-details-title">
           {{t "alexandria.document-details.document-title"}}
-        </div>
+        </label>
         <button
           class="uk-icon-button uk-flex-none"
           type="button"
@@ -41,6 +41,7 @@
           {{#if this.editTitle}}
             <input
               class="uk-input"
+              id="alexandria-details-title"
               type="text"
               placeholder={{t "alexandria.document-details.name-placeholder"}}
               value={{@document.title}}
@@ -77,15 +78,24 @@
         </span>
       </span>
 
-      <p class="uk-flex">
+      <p class="uk-margin-remove-top">
+        <label
+          class="uk-text-meta uk-display-block"
+          for="alexandria-details-description"
+        >
+          {{t "alexandria.document-details.document-description"}}
+        </label>
+
         {{#if this.editDescription}}
           <textarea
             class="uk-textarea"
+            id="alexandria-details-description"
+            rows="10"
             {{on "input" this.updateDocumentDescription}}
           >
             {{~@document.description~}}
           </textarea>
-          <div class="uk-flex uk-flex-column">
+          <div class="uk-text-right">
             <a
               class="uk-icon-button cursor-pointer"
               href="#"
@@ -109,11 +119,7 @@
               {{@document.description}}
             </a>
           {{else}}
-            <a
-              class="uk-link-reset"
-              href="#"
-              {{on "click" (set this.editDescription true)}}
-            >
+            <a href="#" {{on "click" (set this.editDescription true)}}>
               {{t "alexandria.document-details.add-description"}}
             </a>
           {{/if}}

--- a/translations/de.yaml
+++ b/translations/de.yaml
@@ -46,6 +46,7 @@ alexandria:
 
   document-details:
     document-title: "Dokumententitel"
+    document-description: "Dokumentenbeschreibung"
     created-at: "Erstellt am {date}"
     name-placeholder: "Name..."
     version-history: "Versionsgeschichte"

--- a/translations/en.yaml
+++ b/translations/en.yaml
@@ -46,6 +46,7 @@ alexandria:
 
   document-details:
     document-title: "Document title"
+    document-description: "Document description"
     created-at: "Created on {date}"
     name-placeholder: "Name..."
     version-history: "Version history"


### PR DESCRIPTION
This removes the link-reset from the "add" link, adds a title to the description (as per customer request), enlarges the
textarea, and updates the markup to fit.

![Screenshot_20210119_161417](https://user-images.githubusercontent.com/65539425/105053813-a6badb00-5a71-11eb-8f3b-04a5f91ff176.png)

![Screenshot_20210119_161528](https://user-images.githubusercontent.com/65539425/105053815-a8849e80-5a71-11eb-87ea-f931ccbcb3ac.png)

![Screenshot_20210119_161542](https://user-images.githubusercontent.com/65539425/105053823-a9b5cb80-5a71-11eb-8e89-9bc993473ef9.png)
