### PR TITLE
fix(routes): add empty model hook and param options to route

### DIFF
--- a/addon/routes/application.js
+++ b/addon/routes/application.js
@@ -1,10 +1,20 @@
 import Route from "@ember/routing/route";
 import { inject as service } from "@ember/service";
 
+const PARAM_OPTIONS = { refreshModel: true };
+
 export default class ApplicationRoute extends Route {
-  queryParams = { activeGroup: { refreshModel: true } };
+  queryParams = {
+    category: PARAM_OPTIONS,
+    tags: PARAM_OPTIONS,
+    search: PARAM_OPTIONS,
+    document: PARAM_OPTIONS,
+    activeGroup: PARAM_OPTIONS,
+  };
 
   @service config;
+
+  model() {}
 
   afterModel(model, transition) {
     this.config.alexandriaQueryParams = transition.to.parent.params;

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
     "ember-addon",
     "ember-engine"
   ],
-  "repository": "",
+  "repository": "projectcaluma/ember-alexandria",
   "license": "MIT",
   "author": "",
   "directories": {


### PR DESCRIPTION
Without the empty model hook the route throws if activeRoute is set.
And without the additional param configuration those won't work.

No idea why I didn't catch this last time. Maybe the CLI didn't rebuild properly or something :shrug: 

https://github.com/projectcaluma/ember-alexandria/pull/200