### PR TITLE
feat(config): add resolver for user and group IDs 

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,7 +74,6 @@ If you mounted alexandria with query params
 you can access the query params in you config service (as shown in the example
 above) with `this.alexandriaQueryParams.your_query_param`.
 
-
 If you need to access the `alexandriaQueryParams` inside your config check that you define `modelMetaFilters`
 and/or `defaultModelMeta` as getters. If you don't need `alexandriaQueryParams` you
 can ignore the getters and just define the field as usual.
@@ -106,7 +105,23 @@ export default class AlexandriaConfigService extends ConfigService {
 }
 ```
 
+As the Alexandria backend returns IDs for the user and groups you can add a
+resolver from your project to turn the IDs to something the user can relate to.
 
+Just replace the identity functions on the config service.
+
+__Example__:
+```js
+import ConfigService from "ember-alexandria/services/config";
+import { inject as service } from "@ember/service";
+
+export default class AlexandriaConfigService extends ConfigService {
+  @service store;
+  
+  resolveUser(id) { return this.store.peekRecord("user", id); }
+  resolveGroup(id) { return this.store.peekRecord("group", id); }
+}
+```
 
 Contributing
 ------------------------------------------------------------------------------

--- a/addon/components/document-details.hbs
+++ b/addon/components/document-details.hbs
@@ -135,11 +135,11 @@
         </p>
         <p data-test-created-by-user>
           <FaIcon @icon="user" class="uk-margin-small-right" />
-          {{@document.createdByUser}}
+          {{resolve-user @document.createdByUser}}
         </p>
         <p data-test-created-by-group>
           <FaIcon @icon="users" class="uk-margin-small-right" />
-          {{@document.createdByGroup}}
+          {{resolve-group @document.createdByGroup}}
         </p>
       </span>
 
@@ -191,7 +191,7 @@
                     {{moment-format file.createdAt "DD.MM.YYYY HH:mm"}}
                   </span>
                   <span class="uk-width-expand">
-                    {{~file.createdByUser.fullName~}}
+                    {{~resolve-user file.createdByUser~}}
                   </span>
                   <a
                     uk-icon="download"

--- a/addon/helpers/resolve-group.js
+++ b/addon/helpers/resolve-group.js
@@ -1,0 +1,10 @@
+import Helper from "@ember/component/helper";
+import { inject as service } from "@ember/service";
+
+export default class ResolveGroupHelper extends Helper {
+  @service config;
+
+  compute([id]) {
+    return this.config.resolveGroup(id);
+  }
+}

--- a/addon/helpers/resolve-user.js
+++ b/addon/helpers/resolve-user.js
@@ -1,0 +1,10 @@
+import Helper from "@ember/component/helper";
+import { inject as service } from "@ember/service";
+
+export default class ResolveUserHelper extends Helper {
+  @service config;
+
+  compute([id]) {
+    return this.config.resolveUser(id);
+  }
+}

--- a/addon/routes/application.js
+++ b/addon/routes/application.js
@@ -1,10 +1,20 @@
 import Route from "@ember/routing/route";
 import { inject as service } from "@ember/service";
 
+const PARAM_OPTIONS = { refreshModel: true };
+
 export default class ApplicationRoute extends Route {
-  queryParams = { activeGroup: { refreshModel: true } };
+  queryParams = {
+    category: PARAM_OPTIONS,
+    tags: PARAM_OPTIONS,
+    search: PARAM_OPTIONS,
+    document: PARAM_OPTIONS,
+    activeGroup: PARAM_OPTIONS,
+  };
 
   @service config;
+
+  model() {}
 
   afterModel(model, transition) {
     this.config.alexandriaQueryParams = transition.to.parent.params;

--- a/addon/services/config.js
+++ b/addon/services/config.js
@@ -10,6 +10,9 @@ export default class ConfigService extends Service {
    */
   @tracked activeGroup = null;
 
+  resolveUser = (id) => id;
+  resolveGroup = (id) => id;
+
   /**
    * Defaults so we can lookup
    * `this.config.modelMetaFilters.document`

--- a/app/helpers/resolve-group.js
+++ b/app/helpers/resolve-group.js
@@ -1,0 +1,1 @@
+export { default } from "ember-alexandria/helpers/resolve-group";

--- a/app/helpers/resolve-user.js
+++ b/app/helpers/resolve-user.js
@@ -1,0 +1,1 @@
+export { default } from "ember-alexandria/helpers/resolve-user";

--- a/tests/integration/helpers/resolve-group-test.js
+++ b/tests/integration/helpers/resolve-group-test.js
@@ -1,0 +1,16 @@
+import { render } from "@ember/test-helpers";
+import { hbs } from "ember-cli-htmlbars";
+import { setupRenderingTest } from "ember-qunit";
+import { module, test } from "qunit";
+
+module("Integration | Helper | resolve-group", function (hooks) {
+  setupRenderingTest(hooks);
+
+  test("it renders", async function (assert) {
+    this.id = "1234";
+
+    await render(hbs`{{resolve-group this.id}}`);
+
+    assert.equal(this.element.textContent.trim(), "1234");
+  });
+});

--- a/tests/integration/helpers/resolve-user-test.js
+++ b/tests/integration/helpers/resolve-user-test.js
@@ -1,0 +1,16 @@
+import { render } from "@ember/test-helpers";
+import { hbs } from "ember-cli-htmlbars";
+import { setupRenderingTest } from "ember-qunit";
+import { module, test } from "qunit";
+
+module("Integration | Helper | resolve-user", function (hooks) {
+  setupRenderingTest(hooks);
+
+  test("it renders", async function (assert) {
+    this.id = "1234";
+
+    await render(hbs`{{resolve-group this.id}}`);
+
+    assert.equal(this.element.textContent.trim(), "1234");
+  });
+});


### PR DESCRIPTION
The config service has an identity function as default resolvers.

Depends on #207 