### PR TITLE
fix(document-details): open files from history in new window

### DIFF
--- a/addon/components/document-details.hbs
+++ b/addon/components/document-details.hbs
@@ -196,6 +196,8 @@
                   <a
                     uk-icon="download"
                     class="uk-icon-link"
+                    target="_blank"
+                    rel="noopener noreferrer"
                     href={{file.downloadUrl}}
                   ></a>
                 </li>


### PR DESCRIPTION
Otherwise, pictures and other media that can be opened by the browser
will do so in the same window and thus leave the app.