### PR TITLE
fix(document-card): add file extension from last upload to filename

### DIFF
--- a/addon/components/document-card.js
+++ b/addon/components/document-card.js
@@ -13,13 +13,17 @@ export default class DocumentCardComponent extends Component {
 
   @task *download() {
     try {
-      // There is a known issue with file-saver and urls. The filename passed as the second argument is ignored.
-      // https://github.com/eligrey/FileSaver.js/issues/670
-      yield saveAs(
-        this.args.document.files.filter((file) => file.type === "original")[0]
-          .downloadUrl,
-        this.args.document.title
+      const [file] = this.args.document.files.filter(
+        (file) => file.type === "original"
       );
+      const extension = file.name.includes(".")
+        ? `.${file.name.split(".").slice(-1)[0]}`
+        : "";
+
+      // There is a known issue with file-saver and urls.
+      // The filename passed as the second argument is ignored.
+      // https://github.com/eligrey/FileSaver.js/issues/670
+      yield saveAs(file.downloadUrl, this.args.document.title + extension);
     } catch (error) {
       this.notification.danger(this.intl.t("alexandria.errors.save-file"));
     }

--- a/tests/integration/components/document-card-test.js
+++ b/tests/integration/components/document-card-test.js
@@ -36,7 +36,7 @@ module("Integration | Component | document-card", function (hooks) {
 
     this.document = {
       title,
-      files: [{ type: "original", downloadUrl }],
+      files: [{ name: "foo.txt", type: "original", downloadUrl }],
     };
     await render(hbs`<DocumentCard @document={{this.document}}/>`);
 
@@ -49,7 +49,7 @@ module("Integration | Component | document-card", function (hooks) {
     );
     assert.equal(
       stub.args[0][1],
-      title,
+      `${title}.txt`,
       "saveAs was called with correct file name"
     );
   });

--- a/tests/integration/components/document-details-test.js
+++ b/tests/integration/components/document-details-test.js
@@ -62,7 +62,7 @@ module("Integration | Component | document-details", function (hooks) {
 
     this.selectedDocument = {
       title,
-      files: [{ type: "original", downloadUrl }],
+      files: [{ name: "foo.txt", type: "original", downloadUrl }],
     };
 
     await render(hbs`<DocumentDetails @document={{this.selectedDocument}} />`);
@@ -75,7 +75,7 @@ module("Integration | Component | document-details", function (hooks) {
     );
     assert.equal(
       stub.args[0][1],
-      title,
+      `${title}.txt`,
       "saveAs was called with correct file name"
     );
   });


### PR DESCRIPTION
The document title has no extension but the user's OS wants one.