### PR TITLE
chore: disable ember-release scenario for tests and use node v12

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -19,7 +19,7 @@ jobs:
       - uses: actions/checkout@v2
       - uses: actions/setup-node@v1
         with:
-          node-version: 10
+          node-version: 14
 
       - name: Install Dependencies
         run: yarn install
@@ -36,7 +36,7 @@ jobs:
       - uses: actions/checkout@v2
       - uses: actions/setup-node@v1
         with:
-          node-version: 10
+          node-version: 14
 
       - name: Install dependencies (no lockfile)
         run: yarn install --no-lockfile
@@ -59,13 +59,13 @@ jobs:
       matrix:
         scenario:
           - ember-lts-3.24
-          - ember-release
+          # - ember-release
 
     steps:
       - uses: actions/checkout@v2
       - uses: actions/setup-node@v1
         with:
-          node-version: 10
+          node-version: 14
 
       - name: Install dependencies
         run: yarn install


### PR DESCRIPTION
This is only meant for temporarly purpose until we find a solution
for this scenario to work