### PR TITLE
fix: enable ctrl-a in side panel

### DIFF
--- a/addon/components/document-view.js
+++ b/addon/components/document-view.js
@@ -125,6 +125,9 @@ export default class DocumentViewComponent extends Component {
 
   // * DOCUMENT SELECTION
   handleKeyDown(event) {
+    if (this.documents.shortcutsDisabled) {
+      return;
+    }
     if (event.key === "a" && event.ctrlKey) {
       event.preventDefault();
       this.fetchedDocuments.forEach((doc) => {

--- a/addon/components/single-document-details.hbs
+++ b/addon/components/single-document-details.hbs
@@ -53,7 +53,7 @@
             href="#"
             class="uk-icon-button  cursor-pointer"
             uk-icon="icon: close"
-            {{on "click" (set this.editTitle false)}}
+            {{on "click" this.toggleEditTitle}}
           ></a>
         </span>
       {{else}}
@@ -61,7 +61,7 @@
           href="#"
           class="uk-link-reset"
           data-test-title
-          {{on "click" (set this.editTitle true)}}
+          {{on "click" this.toggleEditTitle}}
         >
           {{@document.title}}
         </a>
@@ -97,7 +97,7 @@
           href="#"
           class="uk-icon-button cursor-pointer"
           uk-icon="icon: close"
-          {{on "click" (set this.editDescription false)}}
+          {{on "click" this.toggleEditDescription}}
         ></a>
       </div>
     {{else}}
@@ -105,12 +105,14 @@
         <a
           class="uk-link-reset"
           href="#"
-          {{on "click" (set this.editDescription true)}}
+          {{!-- {{on "click" (set this.editDescription true)}} --}}
+          {{on "click" this.toggleEditDescription}}
         >
           {{@document.description}}
         </a>
       {{else}}
-        <a href="#" {{on "click" (set this.editDescription true)}}>
+        {{!-- <a href="#" {{on "click" (set this.editDescription true)}}> --}}
+        <a href="#" {{on "click" this.toggleEditDescription}}>
           {{t "alexandria.document-details.add-description"}}
         </a>
       {{/if}}

--- a/addon/components/single-document-details.hbs
+++ b/addon/components/single-document-details.hbs
@@ -105,13 +105,11 @@
         <a
           class="uk-link-reset"
           href="#"
-          {{!-- {{on "click" (set this.editDescription true)}} --}}
           {{on "click" this.toggleEditDescription}}
         >
           {{@document.description}}
         </a>
       {{else}}
-        {{!-- <a href="#" {{on "click" (set this.editDescription true)}}> --}}
         <a href="#" {{on "click" this.toggleEditDescription}}>
           {{t "alexandria.document-details.add-description"}}
         </a>

--- a/addon/components/single-document-details.js
+++ b/addon/components/single-document-details.js
@@ -27,10 +27,28 @@ export default class SingleDocumentDetailsComponent extends DocumentCard {
     this.args.document.description = description;
   }
 
+  @action toggleEditDescription() {
+    this.editDescription = !this.editDescription;
+    if (this.editDescription) {
+      this.documents.disableShortcuts();
+    } else {
+      this.documents.enableShortcuts();
+    }
+  }
+  @action toggleEditTitle() {
+    this.editTitle = !this.editTitle;
+    if (this.editTitle) {
+      this.documents.disableShortcuts();
+    } else {
+      this.documents.enableShortcuts();
+    }
+  }
+
   @action resetState() {
     this.editTitle = false;
     this.validTitle = true;
     this.editDescription = false;
+    this.documents.enableShortcuts();
   }
 
   @restartableTask *saveDocument() {

--- a/addon/services/documents.js
+++ b/addon/services/documents.js
@@ -8,6 +8,7 @@ export default class DocumentsService extends Service {
   @service config;
   @service router;
   @tracked selectedDocuments = [];
+  @tracked shortcutsDisabled = false;
 
   constructor(...args) {
     super(...args);
@@ -146,5 +147,12 @@ export default class DocumentsService extends Service {
       (d) => d.id !== doc.id
     );
     this.updateRoute();
+  }
+
+  enableShortcuts() {
+    this.shortcutsDisabled = false;
+  }
+  disableShortcuts() {
+    this.shortcutsDisabled = true;
   }
 }

--- a/tests/integration/components/single-document-details-test.js
+++ b/tests/integration/components/single-document-details-test.js
@@ -13,6 +13,7 @@ const mockDocumentsService = class DocumentsService extends Service {
   deselectDocument() {
     return [];
   }
+  disableShortcuts() {}
 };
 
 module("Integration | Component | single-document-details", function (hooks) {


### PR DESCRIPTION
The multi-document selection, with CTRL+A disabled the usage of CTRL+A in side panel form fields. This fix addresses this.