### PR TITLE
fix: zip download

### DIFF
--- a/addon/components/document-card.js
+++ b/addon/components/document-card.js
@@ -6,6 +6,7 @@ import { saveAs } from "file-saver";
 export default class DocumentCardComponent extends Component {
   @service notification;
   @service intl;
+  @service config;
 
   get showLoadingState() {
     return this.download.isRunning || this.delete.isRunning;
@@ -13,6 +14,7 @@ export default class DocumentCardComponent extends Component {
 
   @task *download() {
     if (this.args.document || this.args?.documents.length === 1) {
+      // If we download a single file we can use the saveAs library
       const doc = this.args.document || this.args?.documents[0];
       try {
         const file = doc.files.find((file) => file.type === "original");
@@ -23,11 +25,13 @@ export default class DocumentCardComponent extends Component {
         // There is a known issue with file-saver and urls.
         // The filename passed as the second argument is ignored.
         // https://github.com/eligrey/FileSaver.js/issues/670
+
         yield saveAs(file.downloadUrl, doc.title + extension);
       } catch {
         this.notification.danger(this.intl.t("alexandria.errors.save-file"));
       }
     } else {
+      // If we want to save a zip of files we need to do some more stuff
       // Compile an array of original file PKs
       const originalFilePKs = encodeURIComponent(
         this.args.documents
@@ -38,8 +42,25 @@ export default class DocumentCardComponent extends Component {
           .join(",")
       );
 
-      const url = `/api/v1/files/multi?filter%5Bfiles%5D=${originalFilePKs}`;
-      yield saveAs(url, `Download-${this.args.documents.length}-files.zip`);
+      let url = this.config?.zipDownloadHost || ""; // in case we need to send the zipDownload to another URL
+      url += this.config?.zipDownloadNamespace || ""; // in case we need to namespace the alexandria api
+      url += "/api/v1/files/multi";
+      url += `?filter[files]=${originalFilePKs}`; // list of files we want to download
+
+      // Some alexandria applications require the document-meta as well
+      if (this.config.modelMetaFilters.document)
+        url += `&filter[document-meta]=${encodeURIComponent(
+          JSON.stringify(this.config.modelMetaFilters.document)
+        )}`;
+
+      const transfer = yield fetch(url, {
+        mode: "cors",
+        headers: {
+          Authorization: `Bearer ${this.config.accessToken}`,
+        },
+      });
+      const bytes = yield transfer.blob();
+      saveAs(bytes, `Download-${this.args.documents.length}-files.zip`);
     }
   }
 }

--- a/addon/components/document-view.js
+++ b/addon/components/document-view.js
@@ -6,7 +6,6 @@ import { lastValue, task } from "ember-concurrency-decorators";
 
 export default class DocumentViewComponent extends Component {
   @service notification;
-  @service config;
   @service store;
   @service intl;
   @service documents;


### PR DESCRIPTION
The zip-download as it currently is in main does not work with all alexandria backend implementations.

As an example, the SoBau alexandria backend requires the `document-meta` to be set which this PR does.