### PR TITLE
fix(list-view): translate list view headers

### DIFF
--- a/addon/components/document-list.hbs
+++ b/addon/components/document-list.hbs
@@ -5,10 +5,10 @@
   <thead>
     <tr>
       <th class="uk-table-shrink">
-        Icon
+        {{t "alexandria.document-list.type"}}
       </th>
       <th class="uk-table-expand">
-        Title
+        {{t "alexandria.document-details.document-title"}}
         <FaIcon
           @icon="sort"
           @prefix="fas"
@@ -20,7 +20,7 @@
         />
       </th>
       <th>
-        Created
+        {{t "alexandria.document-list.created-at"}}
         <FaIcon
           @icon="sort"
           @prefix="fas"
@@ -32,7 +32,7 @@
         />
       </th>
       <th>
-        Group
+        {{t "alexandria.document-list.created-by"}}
         <FaIcon
           @icon="sort"
           @prefix="fas"

--- a/translations/de.yaml
+++ b/translations/de.yaml
@@ -45,6 +45,11 @@ alexandria:
     drop-to-upload: "Datei fallen lassen, um sie hochzuladen"
     drop-not-allowed: "Keine Kategorie ausgewählt"
 
+  document-list:
+    type: "Typ"
+    created-by: "Gruppe"
+    created-at: "Erstellungsdatum"
+
   document-details:
     document-title: "Dokumententitel"
     document-description: "Dokumentenbeschreibung"

--- a/translations/en.yaml
+++ b/translations/en.yaml
@@ -45,6 +45,11 @@ alexandria:
     drop-to-upload: "Drop file to upload"
     drop-not-allowed: "No category selected"
 
+  document-list:
+    type: "Type"
+    created-by: "Group"
+    created-at: "Created"
+
   document-details:
     document-title: "Document title"
     document-description: "Document description"


### PR DESCRIPTION
The headers previously where set statically to english captions. Now makes use of int8-tooling.