### PR TITLE
fix: pin dev dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -51,12 +51,12 @@
     "file-saver": "^2.0.5"
   },
   "devDependencies": {
-    "@adfinis-sygroup/eslint-config": "1.3.2",
+    "@adfinis-sygroup/eslint-config": "1.5.0",
     "@adfinis-sygroup/semantic-release-config": "3.1.0",
     "@embroider/test-setup": "0.43.5",
     "babel-eslint": "10.1.0",
     "broccoli-asset-rev": "3.0.0",
-    "ember-cli": "~3.28.0",
+    "ember-cli": "3.28.3",
     "ember-cli-dependency-checker": "3.2.0",
     "ember-cli-inject-live-reload": "2.1.0",
     "ember-cli-mirage": "1.1.8",
@@ -79,6 +79,7 @@
     "ember-test-selectors": "5.0.0",
     "ember-try": "1.4.0",
     "eslint": "7.32.0",
+    "eslint-config-prettier": "8.3.0",
     "eslint-plugin-ember": "10.5.4",
     "eslint-plugin-import": "2.22.1",
     "eslint-plugin-node": "11.1.0",

--- a/tests/integration/components/document-card-test.js
+++ b/tests/integration/components/document-card-test.js
@@ -82,7 +82,7 @@ module("Integration | Component | document-card", function (hooks) {
     );
   });
 
-  test("delete file", async function (assert) {
+  test("thumbnail", async function (assert) {
     this.document = {
       thumbnail: "some-url",
     };

--- a/tests/integration/components/document-list-item-test.js
+++ b/tests/integration/components/document-list-item-test.js
@@ -41,6 +41,7 @@ module("Integration | Component | document-list-item", function (hooks) {
   });
 
   test("it fires the onClickDocument function with the correct parameter", async function (assert) {
+    assert.expect(1);
     this.set("onClickDocument", (arg) => {
       assert.equal(arg, this.document);
     });

--- a/tests/integration/helpers/resolve-group-test.js
+++ b/tests/integration/helpers/resolve-group-test.js
@@ -11,6 +11,6 @@ module("Integration | Helper | resolve-group", function (hooks) {
 
     await render(hbs`{{resolve-group this.id}}`);
 
-    assert.dom(this.element).hasText('1234');
+    assert.dom(this.element).hasText("1234");
   });
 });

--- a/tests/integration/helpers/resolve-user-test.js
+++ b/tests/integration/helpers/resolve-user-test.js
@@ -11,6 +11,6 @@ module("Integration | Helper | resolve-user", function (hooks) {
 
     await render(hbs`{{resolve-group this.id}}`);
 
-    assert.dom(this.element).hasText('1234');
+    assert.dom(this.element).hasText("1234");
   });
 });

--- a/yarn.lock
+++ b/yarn.lock
@@ -2,14 +2,10 @@
 # yarn lockfile v1
 
 
-"@adfinis-sygroup/eslint-config@1.3.2":
-  version "1.3.2"
-  resolved "https://registry.yarnpkg.com/@adfinis-sygroup/eslint-config/-/eslint-config-1.3.2.tgz#c31077d7c48f4540dd44f92dd974a7b68f69087d"
-  integrity sha512-9+/vZlDrLB05uAOHkm9GzqREY6HqGi8RMrvYwTwL8gJM6S9iQrdP/CNt/kN62ko0QZsngdGCuMnlR22PFu4CTg==
-  dependencies:
-    babel-eslint "^10.0.3"
-    eslint-config-prettier "^6.15.0"
-    prettier "^2.2.0"
+"@adfinis-sygroup/eslint-config@1.5.0":
+  version "1.5.0"
+  resolved "https://registry.yarnpkg.com/@adfinis-sygroup/eslint-config/-/eslint-config-1.5.0.tgz#559ed9aef2311cb48a284b2f43d30c7e616e129a"
+  integrity sha512-BhHH00dJC5fJmz0lf16e355a1ecPzKR4hPpCcYUzzZWb5Ti1OkrAG0ZZxrF6gCIt+0DummdqgRUr74r/zdFNBg==
 
 "@adfinis-sygroup/semantic-release-config@3.1.0":
   version "3.1.0"
@@ -3292,7 +3288,7 @@ babel-core@^6.26.0, babel-core@^6.26.3:
     slash "^1.0.0"
     source-map "^0.5.7"
 
-babel-eslint@10.1.0, babel-eslint@^10.0.3:
+babel-eslint@10.1.0:
   version "10.1.0"
   resolved "https://registry.yarnpkg.com/babel-eslint/-/babel-eslint-10.1.0.tgz#6968e568a910b78fb3779cdd8b6ac2f479943232"
   integrity sha512-ifWaTHQ0ce+448CYop8AdrQiBsGrnC+bMgfyKFdi6EsPLTAWG+QfyDeM6OH+FmWnKvEq5NnBMLvlBUPKQZoDSg==
@@ -6972,10 +6968,10 @@ ember-cli-version-checker@^5.1.1, ember-cli-version-checker@^5.1.2:
     semver "^7.3.4"
     silent-error "^1.1.1"
 
-ember-cli@~3.28.0:
-  version "3.28.0"
-  resolved "https://registry.yarnpkg.com/ember-cli/-/ember-cli-3.28.0.tgz#0a0374c9a1d08386ddf56e8098a38b71dd4453bc"
-  integrity sha512-CrMs5edFQ2ingO2xfT33T4nUEl8SlvBQ7q+XO9L/GFTvFU07slHxYSvGur0cwgQfOiLnkSTnIaVF1oqBnEmfPQ==
+ember-cli@3.28.3:
+  version "3.28.3"
+  resolved "https://registry.yarnpkg.com/ember-cli/-/ember-cli-3.28.3.tgz#3384c3fb018b58111e30efed15a2f6a9b66b84c3"
+  integrity sha512-DddAQAddbyaOU4NAjTt8g+FoCCK/F00kbj9pcHO1lfAUpIUS9JPBoWxxZ3qO08mUNXi50pdQSPVVRWzN7mNz2g==
   dependencies:
     "@babel/core" "^7.13.8"
     "@babel/plugin-transform-modules-amd" "^7.12.1"
@@ -7816,12 +7812,10 @@ escodegen@^2.0.0:
   optionalDependencies:
     source-map "~0.6.1"
 
-eslint-config-prettier@^6.15.0:
-  version "6.15.0"
-  resolved "https://registry.yarnpkg.com/eslint-config-prettier/-/eslint-config-prettier-6.15.0.tgz#7f93f6cb7d45a92f1537a70ecc06366e1ac6fed9"
-  integrity sha512-a1+kOYLR8wMGustcgAjdydMsQ2A/2ipRPwRKUmfYaSxc9ZPcrku080Ctl6zrZzZNs/U82MjSv+qKREkoq3bJaw==
-  dependencies:
-    get-stdin "^6.0.0"
+eslint-config-prettier@8.3.0:
+  version "8.3.0"
+  resolved "https://registry.yarnpkg.com/eslint-config-prettier/-/eslint-config-prettier-8.3.0.tgz#f7471b20b6fe8a9a9254cc684454202886a2dd7a"
+  integrity sha512-BgZuLUSeKzvlL/VUjx/Yb787VQ26RU3gGjA3iiFvdsp/2bMfVIWUVP7tjxtjS0e+HP409cPlPvNkQloz8C91ew==
 
 eslint-import-resolver-node@^0.3.4:
   version "0.3.6"
@@ -9050,11 +9044,6 @@ get-stdin@^4.0.1:
   version "4.0.1"
   resolved "https://registry.yarnpkg.com/get-stdin/-/get-stdin-4.0.1.tgz#b968c6b0a04384324902e8bf1a5df32579a450fe"
   integrity sha1-uWjGsKBDhDJJAui/Gl3zJXmkUP4=
-
-get-stdin@^6.0.0:
-  version "6.0.0"
-  resolved "https://registry.yarnpkg.com/get-stdin/-/get-stdin-6.0.0.tgz#9e09bf712b360ab9225e812048f71fde9c89657b"
-  integrity sha512-jp4tHawyV7+fkkSKyvjuLZswblUtz+SQKzSWnBbii16BuZksJlU1wuBYXY75r+duh/llF1ur6oNwi+2ZzjKZ7g==
 
 get-stream@3.0.0, get-stream@^3.0.0:
   version "3.0.0"
@@ -13734,7 +13723,7 @@ prettier-linter-helpers@^1.0.0:
   dependencies:
     fast-diff "^1.1.2"
 
-prettier@2.3.2, prettier@^2.2.0:
+prettier@2.3.2:
   version "2.3.2"
   resolved "https://registry.yarnpkg.com/prettier/-/prettier-2.3.2.tgz#ef280a05ec253712e486233db5c6f23441e7342d"
   integrity sha512-lnJzDfJ66zkMy58OL5/NY5zp70S7Nz6KqcKkXYzn2tMVrNxvbqaBpg7H3qHaLxCJ5lNMsGuM8+ohS7cZrthdLQ==


### PR DESCRIPTION
The relevant change is the pinning of ember-source to 3.28.1 because of
https://github.com/emberjs/ember.js/issues/19797