### PR TITLE
fix: reset document selection on navigating away

### DIFF
--- a/addon/routes/application.js
+++ b/addon/routes/application.js
@@ -1,5 +1,6 @@
 import Route from "@ember/routing/route";
 import { inject as service } from "@ember/service";
+import { isEmpty } from "@ember/utils";
 
 const PARAM_OPTIONS = { refreshModel: true };
 
@@ -17,6 +18,11 @@ export default class ApplicationRoute extends Route {
   model() {}
 
   afterModel(model, transition) {
+    /* Depending on how ember alexandria is used we might have to reset
+    the document selection on navigation */
+    if (isEmpty(transition.to.queryParams)) {
+      this.documents.clearDocumentSelection();
+    }
     this.config.alexandriaQueryParams = transition.to.parent.params;
     this.config.activeGroup = transition.to.queryParams.activeGroup;
   }


### PR DESCRIPTION
fix: reset document selection on navigating away

Depending on how ember alexandria is used we might have to reset the document selection on navigation.