### PR TITLE
fix: use renamed fields from the backend

### DIFF
--- a/addon/components/document-card.js
+++ b/addon/components/document-card.js
@@ -17,7 +17,7 @@ export default class DocumentCardComponent extends Component {
       // If we download a single file we can use the saveAs library
       const doc = this.args.document || this.args?.documents[0];
       try {
-        const file = doc.files.find((file) => file.type === "original");
+        const file = doc.files.find((file) => file.variant === "original");
         const extension = file.name.includes(".")
           ? `.${file.name.split(".").slice(-1)[0]}`
           : "";
@@ -36,7 +36,7 @@ export default class DocumentCardComponent extends Component {
       const originalFilePKs = encodeURIComponent(
         this.args.documents
           .map((doc) =>
-            doc.files.toArray().find((file) => file.type === "original")
+            doc.files.toArray().find((file) => file.variant === "original")
           )
           .map((f) => f.id)
           .join(",")
@@ -49,7 +49,7 @@ export default class DocumentCardComponent extends Component {
 
       // Some alexandria applications require the document-meta as well
       if (this.config.modelMetaFilters.document) {
-        url += `&filter[document-meta]=${encodeURIComponent(
+        url += `&filter[document-metainfo]=${encodeURIComponent(
           JSON.stringify(this.config.modelMetaFilters.document)
         )}`;
       }

--- a/addon/components/single-document-details.hbs
+++ b/addon/components/single-document-details.hbs
@@ -183,7 +183,7 @@
       </a>
       <div class="uk-accordion-content">
         <ul class="uk-list uk-list-divider">
-          {{#each (filter-by "type" "original" @document.files) as |file|}}
+          {{#each (filter-by "variant" "original" @document.files) as |file|}}
             <li data-test-file class="uk-flex" title={{file.name}}>
               <span class="uk-margin-right">
                 {{format-date

--- a/addon/controllers/application.js
+++ b/addon/controllers/application.js
@@ -33,7 +33,7 @@ export default class ApplicationController extends Controller {
     if (this.config && this.config.modelMetaFilters?.document) {
       filters = {
         ...filters,
-        meta: JSON.stringify(this.config.modelMetaFilters.document),
+        metainfo: JSON.stringify(this.config.modelMetaFilters.document),
       };
     }
 

--- a/addon/models/category.js
+++ b/addon/models/category.js
@@ -5,7 +5,7 @@ export default class CategoryModel extends LocalizedModel {
   @localizedAttr name;
   @localizedAttr description;
   @attr color;
-  @attr meta;
+  @attr metainfo;
 
   @hasMany documents;
 }

--- a/addon/models/document.js
+++ b/addon/models/document.js
@@ -4,7 +4,7 @@ import { LocalizedModel, localizedAttr } from "ember-localized-model";
 export default class DocumentModel extends LocalizedModel {
   @localizedAttr title;
   @localizedAttr description;
-  @attr meta;
+  @attr metainfo;
 
   @attr createdAt;
   @attr createdByUser;
@@ -18,7 +18,9 @@ export default class DocumentModel extends LocalizedModel {
   @hasMany files;
 
   get thumbnail() {
-    const thumbnail = this.files.filter((file) => file.type === "thumbnail")[0];
+    const thumbnail = this.files.filter(
+      (file) => file.variant === "thumbnail"
+    )[0];
     return thumbnail && thumbnail.downloadUrl;
   }
 }

--- a/addon/models/file.js
+++ b/addon/models/file.js
@@ -1,12 +1,12 @@
 import Model, { attr, belongsTo, hasMany } from "@ember-data/model";
 
 export default class FileModel extends Model {
-  @attr type;
+  @attr variant;
   @attr name;
   @attr uploadUrl;
   @attr downloadUrl;
   @attr objectName;
-  @attr meta;
+  @attr metainfo;
 
   @attr createdAt;
   @attr createdByUser;

--- a/addon/models/tag.js
+++ b/addon/models/tag.js
@@ -4,7 +4,7 @@ import { LocalizedModel, localizedAttr } from "ember-localized-model";
 export default class TagModel extends LocalizedModel {
   @attr name;
   @localizedAttr description;
-  @attr meta;
+  @attr metainfo;
 
   @attr createdAt;
   @attr createdByUser;

--- a/addon/services/documents.js
+++ b/addon/services/documents.js
@@ -54,7 +54,7 @@ export default class DocumentsService extends Service {
       Array.from(files).map(async (file) => {
         const documentModel = this.store.createRecord("document", {
           category,
-          meta: this.config.defaultModelMeta.document,
+          metainfo: this.config.defaultModelMeta.document,
           createdByGroup: this.config.activeGroup,
           modifiedByGroup: this.config.activeGroup,
         });
@@ -63,7 +63,7 @@ export default class DocumentsService extends Service {
 
         const fileModel = this.store.createRecord("file", {
           name: file.name,
-          type: "original",
+          variant: "original",
           document: documentModel,
           createdByGroup: this.config.activeGroup,
           modifiedByGroup: this.config.activeGroup,
@@ -93,7 +93,7 @@ export default class DocumentsService extends Service {
   async replace(document, file) {
     const fileModel = this.store.createRecord("file", {
       name: file.name,
-      type: "original",
+      variant: "original",
       document,
       createdByGroup: this.config.activeGroup,
       modifiedByGroup: this.config.activeGroup,

--- a/tests/acceptance/documents-test.js
+++ b/tests/acceptance/documents-test.js
@@ -24,7 +24,7 @@ module("Acceptance | documents", function (hooks) {
     documents[1].update({
       files: [
         this.server.create("file", {
-          type: "thumbnail",
+          variant: "thumbnail",
           downloadUrl: "test-thumbnail",
         }),
       ],
@@ -180,7 +180,7 @@ module("Acceptance | documents", function (hooks) {
     this.assertRequest("POST", "/api/v1/files", (request) => {
       const { attributes } = JSON.parse(request.requestBody).data;
       assert.strictEqual(attributes.name, "test-file.txt");
-      assert.strictEqual(attributes.type, "original");
+      assert.strictEqual(attributes.variant, "original");
     });
     await triggerEvent("[data-test-replace]", "change", {
       files: [new File(["Ember Rules!"], "test-file.txt")],

--- a/tests/dummy/mirage/factories/file.js
+++ b/tests/dummy/mirage/factories/file.js
@@ -6,7 +6,7 @@ export default Factory.extend({
   createdByGroup: "dummy-group",
   createdAt: () => faker.date.past(),
   name: () => faker.lorem.word(),
-  type: "original",
+  variant: "original",
   uploadUrl: "/api/v1/file-upload",
   downloadUrl: () => faker.internet.url(),
 });

--- a/tests/integration/components/document-card-test.js
+++ b/tests/integration/components/document-card-test.js
@@ -44,7 +44,7 @@ module("Integration | Component | document-card", function (hooks) {
 
     this.document = {
       title,
-      files: [{ name: "foo.txt", type: "original", downloadUrl }],
+      files: [{ name: "foo.txt", variant: "original", downloadUrl }],
     };
     await render(hbs`<DocumentCard @document={{this.document}}/>`);
     await click("[data-test-context-menu-trigger]");

--- a/tests/integration/components/single-document-details-test.js
+++ b/tests/integration/components/single-document-details-test.js
@@ -34,7 +34,7 @@ module("Integration | Component | single-document-details", function (hooks) {
       createdByGroup: "group1",
       files: [
         {
-          type: "original",
+          variant: "original",
           name: "some-file.pdf",
           createdByUser: null,
           downloadUrl: "http://test.com",

--- a/tests/unit/controllers/application-test.js
+++ b/tests/unit/controllers/application-test.js
@@ -18,7 +18,7 @@ module("Unit | Controller | application", function (hooks) {
     assert.deepEqual(controller.documentFilters, {
       activeGroup: "group",
       category: 1,
-      meta: JSON.stringify([{ key: "instance_id", value: "1" }]),
+      metainfo: JSON.stringify([{ key: "instance_id", value: "1" }]),
       search: "test",
       tags: undefined,
     });


### PR DESCRIPTION
alexandria renamed meta to metadata and type to variant

relies on https://github.com/projectcaluma/alexandria/pull/285, #414 