### PR TITLE
fix(tags): improve adding a new tag

### DIFF
--- a/addon/services/tags.js
+++ b/addon/services/tags.js
@@ -64,15 +64,19 @@ export default class TagsService extends Service {
       }
     }
 
-    if ((await document.tags).find((t) => t.id === tag.id)) {
+    const tags = await document.tags;
+
+    if (tags.find((t) => t.id === tag.id)) {
       return tag;
     }
 
-    (await document.tags).push(tag);
+    tags.push(tag);
     await document.save();
 
-    await this.fetchAllTags.perform();
-    await this.fetchSearchTags.perform();
+    await Promise.all([
+      this.fetchAllTags.perform(),
+      this.fetchSearchTags.perform(),
+    ]);
 
     return tag;
   }

--- a/tests/dummy/mirage/config.js
+++ b/tests/dummy/mirage/config.js
@@ -20,6 +20,7 @@ export default function makeServer(config) {
       this.get("/tags");
       this.get("/tags/:id");
       this.post("/tags");
+      this.patch("/tags/:id");
 
       this.post("/files", function (schema) {
         const attrs = this.normalizedRequestAttrs();


### PR DESCRIPTION
Previous implementation has a prod only bug where the line `(await document.tags).push(tag)` produced the error `(intermediate value).push is not a function`