### PR TITLE
fix(services): namespace all services

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ constructor(...args) {
           "session",
           "intl",
           "notification",
-          { config: "alexandria-config" },
+          "alexandria-config",
         ],
       },
     },
@@ -63,8 +63,8 @@ meta value for a model should be. Each configuration field is scoped by model na
 (check out the example to understand what is meant by this).
 
 For this you need to create a service extending from
-`ember-alexandria/services/config` which you then have to pass as `config` to
-alexandria.
+`ember-alexandria/services/alexandria-config` which you then have to pass as
+`alexandria-config` to alexandria.
 
 This is needed since an engine does not merge its env into the host apps.
 See https://github.com/ember-engines/ember-engines/issues/176 for more info.
@@ -81,9 +81,9 @@ can ignore the getters and just define the field as usual.
 **Example**:
 
 ```js
-import ConfigService from "ember-alexandria/services/config";
+import AlexandriaConfigService from "ember-alexandria/services/alexandria-config";
 
-export default class AlexandriaConfigService extends ConfigService {
+export default class CustomAlexandriaConfigService extends AlexandriaConfigService {
   get modelMetaFilters() {
     return {
       document: [
@@ -122,17 +122,22 @@ With it you for example fetch the users and groups of the documents in a batch.
 **Example**:
 
 ```js
-import ConfigService from "ember-alexandria/services/config";
+import AlexandriaConfigService from "ember-alexandria/services/alexandria-config";
 import { inject as service } from "@ember/service";
 
-export default class AlexandriaConfigService extends ConfigService {
+export default class CustomAlexandriaConfigService extends AlexandriaConfigService {
   @service store;
-  
+
   activeUser = 1;
   activeGroup = 1;
 
-  resolveUser(id) { return this.store.peekRecord("user", id); }
-  resolveGroup(id) { return this.store.peekRecord("group", id); }
+  resolveUser(id) {
+    return this.store.peekRecord("user", id);
+  }
+
+  resolveGroup(id) {
+    return this.store.peekRecord("group", id);
+  }
 
   documentsPostProcess(documents) {
     const users = documents.map((d) => d.createdByUser);
@@ -141,7 +146,7 @@ export default class AlexandriaConfigService extends ConfigService {
     this.store.query("user", { filter: { id: users.join(",") } });
     this.store.query("group", { filter: { id: groups.join(",") } });
 
-    return documents
+    return documents;
   }
 }
 ```
@@ -155,6 +160,7 @@ Additionally to tags you can configure marks. Marks are similar to tags, but are
 The icons for marks are from [FontAwesome](https://fontawesome.com/search?o=r&m=free&s=regular%2Csolid).
 
 The object for a mark has the following properties:
+
 - `type`: This is the id of a tag used to identify the mark in the backend.
 - `icon`: This a string, which references an FontAwesome.
 - `tooltip`: This is shown when hovering over the mark.
@@ -162,9 +168,9 @@ The object for a mark has the following properties:
 An example configuration with two icons might look like this:
 
 ```js
-import ConfigService from "ember-alexandria/services/config";
+import AlexandriaConfigService from "ember-alexandria/services/alexandria-config";
 
-export default class AlexandriaConfigService extends ConfigService {
+export default class CustomAlexandriaConfigService extends AlexandriaConfigService {
   get marks() {
     return [
       {
@@ -183,6 +189,7 @@ export default class AlexandriaConfigService extends ConfigService {
 ```
 
 Configure used icons in `config/icons.js`
+
 ```js
 module.exports = function () {
   return {
@@ -190,7 +197,6 @@ module.exports = function () {
   };
 };
 ```
-
 
 ## Contributing
 

--- a/addon/adapters/application.js
+++ b/addon/adapters/application.js
@@ -2,7 +2,7 @@ import { inject as service } from "@ember/service";
 import OIDCJSONAPIAdapter from "ember-simple-auth-oidc/adapters/oidc-json-api-adapter";
 
 export default class ApplicationAdapter extends OIDCJSONAPIAdapter {
-  @service config;
+  @service("alexandria-config") config;
   @service session;
 
   get namespace() {

--- a/addon/components/category-nav/category.js
+++ b/addon/components/category-nav/category.js
@@ -5,7 +5,7 @@ import Component from "@glimmer/component";
 import { tracked } from "@glimmer/tracking";
 
 export default class CategoryNavCategoryComponent extends Component {
-  @service documents;
+  @service("alexandria-documents") documents;
   @service router;
 
   @tracked collapseChildren = false;

--- a/addon/components/document-card.js
+++ b/addon/components/document-card.js
@@ -8,7 +8,7 @@ import { ErrorHandler } from "ember-alexandria/helpers/error-handler";
 export default class DocumentCardComponent extends Component {
   @service notification;
   @service intl;
-  @service config;
+  @service("alexandria-config") config;
 
   get classes() {
     const classes = [

--- a/addon/components/document-delete-button.js
+++ b/addon/components/document-delete-button.js
@@ -9,7 +9,7 @@ import { ErrorHandler } from "ember-alexandria/helpers/error-handler";
 export default class DocumentDeleteButtonComponent extends Component {
   @service notification;
   @service intl;
-  @service documents;
+  @service("alexandria-documents") documents;
   @service router;
 
   @tracked dialogVisible = false;

--- a/addon/components/document-upload-button.js
+++ b/addon/components/document-upload-button.js
@@ -9,7 +9,7 @@ export default class DocumentUploadButtonComponent extends Component {
   @service notification;
   @service intl;
   @service store;
-  @service documents;
+  @service("alexandria-documents") documents;
 
   categories = query(this, "category", () => ({
     "filter[hasParent]": false,

--- a/addon/components/document-view.js
+++ b/addon/components/document-view.js
@@ -11,9 +11,9 @@ export default class DocumentViewComponent extends Component {
   @service notification;
   @service store;
   @service intl;
-  @service documents;
+  @service("alexandria-documents") documents;
   @service router;
-  @service config;
+  @service("alexandria-config") config;
 
   @tracked isDragOver = false;
   @tracked dragCounter = 0;

--- a/addon/components/documents-side-panel.js
+++ b/addon/components/documents-side-panel.js
@@ -1,5 +1,5 @@
 import { inject as service } from "@ember/service";
 import Component from "@glimmer/component";
 export default class DocumentsSidePanelComponent extends Component {
-  @service sidePanel;
+  @service("alexandria-side-panel") sidePanel;
 }

--- a/addon/components/mark-manager.js
+++ b/addon/components/mark-manager.js
@@ -1,7 +1,7 @@
 import { inject as service } from "@ember/service";
 import Component from "@glimmer/component";
 export default class TagManagerComponent extends Component {
-  @service marks;
+  @service("alexandria-marks") marks;
 
   get documents() {
     return this.args.documents.filter((document) => !document.isDeleted);

--- a/addon/components/mark-manager/mark.js
+++ b/addon/components/mark-manager/mark.js
@@ -3,7 +3,7 @@ import { inject as service } from "@ember/service";
 import Component from "@glimmer/component";
 
 export default class MarkManagerMarkComponent extends Component {
-  @service marks;
+  @service("alexandria-marks") marks;
 
   get activeDocumentCount() {
     return this.args.documents.reduce((acc, doc) => {

--- a/addon/components/multi-document-details.js
+++ b/addon/components/multi-document-details.js
@@ -1,7 +1,7 @@
 import { inject as service } from "@ember/service";
 import Component from "@glimmer/component";
 export default class MultiDocumentDetailsComponent extends Component {
-  @service sidePanel;
+  @service("alexandria-side-panel") sidePanel;
 
   get mergedTags() {
     const tags = [];

--- a/addon/components/side-panel-toggle.js
+++ b/addon/components/side-panel-toggle.js
@@ -2,5 +2,5 @@ import { inject as service } from "@ember/service";
 import Component from "@glimmer/component";
 
 export default class SidePanelToggleComponent extends Component {
-  @service sidePanel;
+  @service("alexandria-side-panel") sidePanel;
 }

--- a/addon/components/single-document-details.js
+++ b/addon/components/single-document-details.js
@@ -12,9 +12,9 @@ import { ErrorHandler } from "ember-alexandria/helpers/error-handler";
 // be inheriting from DocumentCard
 export default class SingleDocumentDetailsComponent extends DocumentCard {
   @service router;
-  @service documents;
-  @service tags;
-  @service sidePanel;
+  @service("alexandria-documents") documents;
+  @service("alexandria-tags") tags;
+  @service("alexandria-side-panel") sidePanel;
   @service intl;
 
   @tracked editTitle = false;

--- a/addon/components/tag-filter.js
+++ b/addon/components/tag-filter.js
@@ -4,8 +4,8 @@ import Component from "@glimmer/component";
 import { trackedFunction } from "ember-resources/util/function";
 export default class TagFilterComponent extends Component {
   @service router;
-  @service tags;
-  @service marks;
+  @service("alexandria-tags") tags;
+  @service("alexandria-marks") marks;
   @service store;
 
   get parsedSelected() {

--- a/addon/components/tag-manager.js
+++ b/addon/components/tag-manager.js
@@ -8,7 +8,7 @@ import { trackedFunction } from "ember-resources/util/function";
 
 export default class TagManagerComponent extends Component {
   @service("tags") tagService;
-  @service config;
+  @service("alexandria-config") config;
   @service store;
 
   @tracked tagValue;

--- a/addon/controllers/application.js
+++ b/addon/controllers/application.js
@@ -13,7 +13,7 @@ export default class ApplicationController extends Controller {
     "sort",
   ];
 
-  @service config;
+  @service("alexandria-config") config;
 
   @tracked category;
   @tracked tags = [];

--- a/addon/engine.js
+++ b/addon/engine.js
@@ -11,7 +11,7 @@ export default class EmberAlexandriaEngine extends Engine {
   Resolver = Resolver;
 
   dependencies = {
-    services: ["session", "intl", "notification", "config"],
+    services: ["session", "intl", "notification", "alexandria-config"],
   };
 }
 

--- a/addon/helpers/resolve-group.js
+++ b/addon/helpers/resolve-group.js
@@ -2,7 +2,7 @@ import Helper from "@ember/component/helper";
 import { inject as service } from "@ember/service";
 
 export default class ResolveGroupHelper extends Helper {
-  @service config;
+  @service("alexandria-config") config;
 
   compute([id]) {
     return this.config.resolveGroup(id);

--- a/addon/helpers/resolve-user.js
+++ b/addon/helpers/resolve-user.js
@@ -2,7 +2,7 @@ import Helper from "@ember/component/helper";
 import { inject as service } from "@ember/service";
 
 export default class ResolveUserHelper extends Helper {
-  @service config;
+  @service("alexandria-config") config;
 
   compute([id]) {
     return this.config.resolveUser(id);

--- a/addon/models/document.js
+++ b/addon/models/document.js
@@ -20,7 +20,7 @@ export default class DocumentModel extends LocalizedModel {
   @hasMany("mark", { inverse: "documents", async: true }) marks;
   @hasMany("file", { inverse: "document", async: true }) files;
 
-  @service config;
+  @service("alexandria-config") config;
 
   get thumbnail() {
     const thumbnail = this.files.filter(

--- a/addon/models/mark.js
+++ b/addon/models/mark.js
@@ -3,7 +3,7 @@ import { attr, hasMany } from "@ember-data/model";
 import { LocalizedModel, localizedAttr } from "ember-localized-model";
 
 export default class MarkModel extends LocalizedModel {
-  @service config;
+  @service("alexandria-config") config;
 
   @localizedAttr name;
   @localizedAttr description;

--- a/addon/routes/application.js
+++ b/addon/routes/application.js
@@ -14,9 +14,9 @@ export default class ApplicationRoute extends Route {
     activeGroup: PARAM_OPTIONS,
   };
 
-  @service config;
-  @service documents;
-  @service marks;
+  @service("alexandria-config") config;
+  @service("alexandria-documents") documents;
+  @service("alexandria-marks") marks;
 
   model() {}
 

--- a/addon/services/alexandria-config.js
+++ b/addon/services/alexandria-config.js
@@ -1,7 +1,7 @@
 import Service from "@ember/service";
 import { tracked } from "@glimmer/tracking";
 
-export default class ConfigService extends Service {
+export default class AlexandriaConfigService extends Service {
   markIcons = {};
 
   @tracked alexandriaQueryParams = {};

--- a/addon/services/alexandria-documents.js
+++ b/addon/services/alexandria-documents.js
@@ -3,9 +3,9 @@ import Service, { inject as service } from "@ember/service";
 import { tracked } from "@glimmer/tracking";
 import fetch from "fetch";
 
-export default class DocumentsService extends Service {
+export default class AlexandriaDocumentsService extends Service {
   @service store;
-  @service config;
+  @service("alexandria-config") config;
   @service router;
   @tracked selectedDocuments = [];
   @tracked shortcutsDisabled = false;

--- a/addon/services/alexandria-marks.js
+++ b/addon/services/alexandria-marks.js
@@ -4,7 +4,7 @@ import { findAll } from "ember-data-resources";
 
 import { ErrorHandler } from "ember-alexandria/helpers/error-handler";
 
-export default class MarksService extends Service {
+export default class AlexandriaMarksService extends Service {
   @service store;
 
   marks = findAll(this, "mark");

--- a/addon/services/alexandria-side-panel.js
+++ b/addon/services/alexandria-side-panel.js
@@ -1,7 +1,8 @@
 import { action } from "@ember/object";
 import Service from "@ember/service";
 import { tracked } from "@glimmer/tracking";
-export default class SidePanelService extends Service {
+
+export default class AlexandriaSidePanelService extends Service {
   @tracked open = true;
 
   /**

--- a/addon/services/alexandria-tags.js
+++ b/addon/services/alexandria-tags.js
@@ -5,9 +5,9 @@ import { tracked } from "@glimmer/tracking";
 
 import { ErrorHandler } from "ember-alexandria/helpers/error-handler";
 
-export default class TagsService extends Service {
+export default class AlexandriaTagsService extends Service {
   @service store;
-  @service config;
+  @service("alexandria-config") config;
 
   @tracked categoryCache;
 

--- a/tests/dummy/app/app.js
+++ b/tests/dummy/app/app.js
@@ -12,12 +12,7 @@ export default class App extends Application {
   engines = {
     "ember-alexandria": {
       dependencies: {
-        services: [
-          "session",
-          "intl",
-          "notification",
-          { config: "alexandria-config" },
-        ],
+        services: ["session", "intl", "notification", "alexandria-config"],
       },
     },
   };

--- a/tests/dummy/app/services/alexandria-config.js
+++ b/tests/dummy/app/services/alexandria-config.js
@@ -1,6 +1,9 @@
-import ConfigService from "ember-alexandria/services/config";
+import { later } from "@ember/runloop";
+import { macroCondition, isTesting } from "@embroider/macros";
 
-export default class AlexandriaConfigService extends ConfigService {
+import AlexandriaConfigService from "ember-alexandria/services/alexandria-config";
+
+export default class CustomAlexandriaConfigService extends AlexandriaConfigService {
   markIcons = {
     decision: "stamp",
   };
@@ -28,8 +31,10 @@ export default class AlexandriaConfigService extends ConfigService {
   }
 
   resolveUser(id) {
+    const timeout = macroCondition(isTesting()) ? 1 : 200;
+
     return new Promise((resolve) =>
-      setTimeout(() => resolve((id || "").toUpperCase()), 200),
+      later(this, () => resolve((id || "").toUpperCase()), timeout),
     );
   }
 }

--- a/tests/integration/components/document-card-test.js
+++ b/tests/integration/components/document-card-test.js
@@ -16,7 +16,7 @@ module("Integration | Component | document-card", function (hooks) {
   setupRenderingTest(hooks);
 
   hooks.beforeEach(function () {
-    this.owner.register("service:documents", mockDocumentsService);
+    this.owner.register("service:alexandria-documents", mockDocumentsService);
   });
 
   test("it renders document card", async function (assert) {

--- a/tests/integration/components/document-list-item-test.js
+++ b/tests/integration/components/document-list-item-test.js
@@ -12,7 +12,7 @@ module("Integration | Component | document-list-item", function (hooks) {
     this.document = {
       title: "some document",
       modifiedAt: new Date("December 1, 2000 00:00:00"),
-      createdByUser: "some group",
+      createdByUser: "some user",
       marks: [],
     };
     this.isSelected = false;
@@ -33,7 +33,7 @@ module("Integration | Component | document-list-item", function (hooks) {
   test("it renders all the required fields for a document", async function (assert) {
     assert.dom().includesText("some document");
     assert.dom().includesText("12/01/2000");
-    assert.dom().includesText("some group");
+    assert.dom().includesText("SOME USER");
   });
 
   test("it fires the onClickDocument function with the correct parameter", async function (assert) {

--- a/tests/integration/components/document-upload-button-test.js
+++ b/tests/integration/components/document-upload-button-test.js
@@ -11,7 +11,8 @@ module("Integration | Component | document-upload-button", function (hooks) {
 
   hooks.beforeEach(function () {
     this.uploadFnMock = fake();
-    this.owner.lookup("service:documents").upload = this.uploadFnMock;
+    this.owner.lookup("service:alexandria-documents").upload =
+      this.uploadFnMock;
   });
 
   test("upload a file with a predefined category", async function (assert) {

--- a/tests/integration/components/document-view-test.js
+++ b/tests/integration/components/document-view-test.js
@@ -15,7 +15,7 @@ module("Integration | Component | document-view", function (hooks) {
   setupMirage(hooks);
 
   hooks.beforeEach(function () {
-    this.owner.register("service:documents", MockDocumentsService);
+    this.owner.register("service:alexandria-documents", MockDocumentsService);
   });
 
   test("it renders the documents when in grid view", async function (assert) {
@@ -44,7 +44,7 @@ module("Integration | Component | document-view", function (hooks) {
 
   test("select document", async function (assert) {
     const documents = this.server.createList("document", 3);
-    const docService = this.owner.lookup("service:documents");
+    const docService = this.owner.lookup("service:alexandria-documents");
 
     docService.selectedDocuments = [documents[0]];
 

--- a/tests/integration/components/single-document-details-test.js
+++ b/tests/integration/components/single-document-details-test.js
@@ -22,7 +22,7 @@ module("Integration | Component | single-document-details", function (hooks) {
   setupMirage(hooks);
 
   hooks.beforeEach(function () {
-    this.owner.register("service:documents", mockDocumentsService);
+    this.owner.register("service:alexandria-documents", mockDocumentsService);
   });
 
   test("it renders document information", async function (assert) {
@@ -53,7 +53,7 @@ module("Integration | Component | single-document-details", function (hooks) {
     assert.dom("[data-test-created-at]").hasText("12/11/1998, 12:00 AM");
     assert
       .dom("[data-test-created-by-user]")
-      .hasText(this.selectedDocument.createdByUser);
+      .hasText(this.selectedDocument.createdByUser.toUpperCase());
     assert
       .dom("[data-test-created-by-group]")
       .hasText(this.selectedDocument.createdByGroup);

--- a/tests/unit/services/alexandria-documents-test.js
+++ b/tests/unit/services/alexandria-documents-test.js
@@ -2,17 +2,17 @@ import { setupTest } from "dummy/tests/helpers";
 import { setupMirage } from "ember-cli-mirage/test-support";
 import { module, test } from "qunit";
 
-module("Unit | Service | documents", function (hooks) {
+module("Unit | Service | alexandria-documents", function (hooks) {
   setupTest(hooks);
   setupMirage(hooks);
 
   test("it exists", function (assert) {
-    const service = this.owner.lookup("service:documents");
+    const service = this.owner.lookup("service:alexandria-documents");
     assert.ok(service);
   });
 
   test("it uploads documents", async function (assert) {
-    const service = this.owner.lookup("service:documents");
+    const service = this.owner.lookup("service:alexandria-documents");
     const store = this.owner.lookup("service:store");
 
     const category = await store.findRecord(
@@ -51,7 +51,7 @@ module("Unit | Service | documents", function (hooks) {
   });
 
   test("it replaces documents", async function (assert) {
-    const service = this.owner.lookup("service:documents");
+    const service = this.owner.lookup("service:alexandria-documents");
     const store = this.owner.lookup("service:store");
 
     const document = await store.findRecord(

--- a/tests/unit/services/alexandria-tags-test.js
+++ b/tests/unit/services/alexandria-tags-test.js
@@ -2,19 +2,19 @@ import { setupTest } from "dummy/tests/helpers";
 import { setupMirage } from "ember-cli-mirage/test-support";
 import { module, test } from "qunit";
 
-module("Unit | Service | tags", function (hooks) {
+module("Unit | Service | alexandria-tags", function (hooks) {
   setupTest(hooks);
   setupMirage(hooks);
 
   test("it exists", function (assert) {
-    const service = this.owner.lookup("service:tags");
+    const service = this.owner.lookup("service:alexandria-tags");
     assert.ok(service);
   });
 
   test("it adds existing tags", async function (assert) {
     const requests = this.server.pretender.handledRequests;
 
-    const service = this.owner.lookup("service:tags");
+    const service = this.owner.lookup("service:alexandria-tags");
     const store = this.owner.lookup("service:store");
 
     const document = await store.createRecord("document").save();
@@ -37,7 +37,7 @@ module("Unit | Service | tags", function (hooks) {
   test("it adds new tags", async function (assert) {
     const requests = this.server.pretender.handledRequests;
 
-    const service = this.owner.lookup("service:tags");
+    const service = this.owner.lookup("service:alexandria-tags");
     const store = this.owner.lookup("service:store");
 
     const document = await store.createRecord("document").save();
@@ -61,7 +61,7 @@ module("Unit | Service | tags", function (hooks) {
   test("it removes tags", async function (assert) {
     const requests = this.server.pretender.handledRequests;
 
-    const service = this.owner.lookup("service:tags");
+    const service = this.owner.lookup("service:alexandria-tags");
     const store = this.owner.lookup("service:store");
 
     const document = await store.createRecord("document").save();


### PR DESCRIPTION
BREAKING CHANGE: All services are now namespaced with "alexandria-". If your host app customized the config service, you'll need to remove the name customization in the passed services to the engine.

For further information, please take a look at the readme.