### PR TITLE
chore(compatibility): add compatibility tests for ember LTS 5.4

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -51,9 +51,8 @@ jobs:
       fail-fast: false
       matrix:
         try-scenario:
-          - ember-lts-4.4
-          - ember-lts-4.8
           - ember-lts-4.12
+          - ember-lts-5.4
           - ember-release
           - ember-beta
           - ember-canary

--- a/tests/dummy/config/ember-try.js
+++ b/tests/dummy/config/ember-try.js
@@ -8,26 +8,18 @@ module.exports = async function () {
     usePnpm: true,
     scenarios: [
       {
-        name: "ember-lts-4.4",
-        npm: {
-          devDependencies: {
-            "ember-source": "~4.4.0",
-          },
-        },
-      },
-      {
-        name: "ember-lts-4.8",
-        npm: {
-          devDependencies: {
-            "ember-source": "~4.8.0",
-          },
-        },
-      },
-      {
         name: "ember-lts-4.12",
         npm: {
           devDependencies: {
             "ember-source": "~4.12.0",
+          },
+        },
+      },
+      {
+        name: "ember-lts-5.4",
+        npm: {
+          devDependencies: {
+            "ember-source": "~5.4.0",
           },
         },
       },


### PR DESCRIPTION
BREAKING CHANGE: Remove support for deprecated ember LTS versions 4.4 and 4.8.