### PR TITLE
fix: remove call of inexistent function afterUpload

### DIFF
--- a/addon/components/document-view.js
+++ b/addon/components/document-view.js
@@ -126,7 +126,7 @@ export default class DocumentViewComponent extends Component {
           count: files.length,
         }),
       );
-      this.afterUpload();
+      this.refreshDocumentList();
     } catch (error) {
       new ErrorHandler(this, error).notify(
         "alexandria.errors.upload-document",


### PR DESCRIPTION
This fixes an issue when uploading a file via drag & drop:
![image](https://github.com/projectcaluma/ember-alexandria/assets/7962156/eefe1c8a-019e-4413-92e7-0dd2aaf83d60)
This might have been a regression from moving `afterUpload` to the `document-upload-button` component? I couldn't find any references to the method anywhere else ...