### PR TITLE
fix(delete): delete concurrently and clean up correctly

### DIFF
--- a/addon/services/alexandria-documents.js
+++ b/addon/services/alexandria-documents.js
@@ -38,6 +38,7 @@ export default class AlexandriaDocumentsService extends Service {
       this.selectedDocuments.length === 0
         ? undefined
         : this.selectedDocuments.map((d) => d.id);
+
     this.router.transitionTo(this.router.currentRouteName, {
       queryParams: {
         document: docs,

--- a/tests/integration/components/document-card-test.js
+++ b/tests/integration/components/document-card-test.js
@@ -24,6 +24,9 @@ module("Integration | Component | document-card", function (hooks) {
   });
 
   test("delete file", async function (assert) {
+    const transitionTo = fake();
+    this.owner.lookup("service:router").transitionTo = transitionTo;
+
     const destroy = fake();
     this.document = {
       id: 1,
@@ -36,6 +39,7 @@ module("Integration | Component | document-card", function (hooks) {
     await click("[data-test-delete]");
     await click("[data-test-delete-confirm]");
     assert.ok(destroy.calledOnce, "destroyRecord was called once");
+    assert.ok(transitionTo.calledOnce, "transitionTo was called once");
   });
 
   test("thumbnail", async function (assert) {

--- a/tests/integration/components/document-delete-button-test.js
+++ b/tests/integration/components/document-delete-button-test.js
@@ -2,15 +2,22 @@ import { render, click } from "@ember/test-helpers";
 import { setupRenderingTest } from "dummy/tests/helpers";
 import { hbs } from "ember-cli-htmlbars";
 import { module, test } from "qunit";
+import { fake } from "sinon";
 
 module("Integration | Component | document-delete-button", function (hooks) {
   setupRenderingTest(hooks);
+
+  hooks.beforeEach(function () {
+    this.owner.lookup("service:router").transitionTo = fake();
+  });
 
   test("delete document", async function (assert) {
     this.document = {
       id: 1,
       title: "Test",
-      destroyRecord() {},
+      destroyRecord() {
+        assert.step("destroy test");
+      },
     };
 
     this.onCancel = () => assert.step("cancel");
@@ -18,16 +25,18 @@ module("Integration | Component | document-delete-button", function (hooks) {
 
     await render(hbs`
     <DocumentDeleteButton
-      @document={{this.document}}
+      @docsToDelete={{this.document}}
       @onConfirm={{this.onConfirm}}
       @onCancel={{this.onCancel}}
       as |showDialog|
     >
       <button
-      {{on "click" showDialog}}
-      data-test-delete
-      type="button"
-      >Delete</button>
+        {{on "click" showDialog}}
+        data-test-delete
+        type="button"
+      >
+        Delete
+      </button>
     </DocumentDeleteButton>
     `);
 
@@ -37,6 +46,53 @@ module("Integration | Component | document-delete-button", function (hooks) {
     await click("[data-test-delete]");
     await click("[data-test-delete-confirm]");
 
-    assert.verifySteps(["cancel", "confirm"]);
+    assert.verifySteps(["cancel", "confirm", "destroy test"]);
+  });
+
+  test("delete document multiple", async function (assert) {
+    this.documents = [
+      {
+        id: 1,
+        title: "Test",
+        destroyRecord() {
+          assert.step("destroy test");
+        },
+      },
+      {
+        id: 2,
+        title: "Bar",
+        destroyRecord() {
+          assert.step("destroy bar");
+        },
+      },
+    ];
+
+    this.onCancel = () => assert.step("cancel");
+    this.onConfirm = () => assert.step("confirm");
+
+    await render(hbs`
+    <DocumentDeleteButton
+      @docsToDelete={{this.documents}}
+      @onConfirm={{this.onConfirm}}
+      @onCancel={{this.onCancel}}
+      as |showDialog|
+    >
+      <button
+        {{on "click" showDialog}}
+        data-test-delete
+        type="button"
+      >
+        Delete
+      </button>
+    </DocumentDeleteButton>
+    `);
+
+    await click("[data-test-delete]");
+    await click("[data-test-delete-cancel]");
+
+    await click("[data-test-delete]");
+    await click("[data-test-delete-confirm]");
+
+    assert.verifySteps(["cancel", "confirm", "destroy test", "destroy bar"]);
   });
 });

--- a/tests/integration/components/single-document-details-test.js
+++ b/tests/integration/components/single-document-details-test.js
@@ -51,12 +51,16 @@ module("Integration | Component | single-document-details", function (hooks) {
   });
 
   test("delete document", async function (assert) {
+    const transitionTo = fake();
+    this.owner.lookup("service:router").transitionTo = transitionTo;
+
     const destroy = fake();
     this.selectedDocument = {
       id: 1,
       title: "Test",
       destroyRecord: async () => destroy(),
     };
+
     await render(
       hbs`<SingleDocumentDetails @document={{this.selectedDocument}}/>`,
     );
@@ -65,6 +69,7 @@ module("Integration | Component | single-document-details", function (hooks) {
     await click("[data-test-delete-confirm]");
 
     assert.ok(destroy.calledOnce, "destroyRecord was called once");
+    assert.ok(transitionTo.calledOnce, "transitionTo was called once");
   });
 
   test("edit document title", async function (assert) {


### PR DESCRIPTION
fixes bug when deleting multiple the last one keeps the side panel open, eventhough it does not exist anymore

and its **10x** or so faster (promise.all ftw)

- [x] modal tests fail as always..