### PR TITLE
fix(mime): softer mime type checking

### DIFF
--- a/addon/services/alexandria-documents.js
+++ b/addon/services/alexandria-documents.js
@@ -63,7 +63,7 @@ export default class AlexandriaDocumentsService extends Service {
       if (
         category.allowedMimeTypes &&
         !category.allowedMimeTypes.includes(
-          file.type ?? mime.getType(file.name.split(".").pop()),
+          file.type || mime.getType(file.name.split(".").pop()),
         )
       ) {
         return this.notification.danger(


### PR DESCRIPTION
`file.type` is an empty string not null, therefore not triggering the alternative logic