### PR TITLE
fix: remove content attr in serialization for patch

### DIFF
--- a/addon/serializers/document.js
+++ b/addon/serializers/document.js
@@ -19,4 +19,13 @@ export default class DocumentSerializer extends LocalizedSerializer {
 
     return formData;
   }
+
+  serialize(...args) {
+    const json = super.serialize(...args);
+
+    // delete content attribute, as it is only needed for POST
+    delete json.data.attributes.content;
+
+    return json;
+  }
 }

--- a/tests/unit/serializers/document-test.js
+++ b/tests/unit/serializers/document-test.js
@@ -4,19 +4,34 @@ import { module, test } from "qunit";
 module("Unit | Serializer | document", function (hooks) {
   setupTest(hooks);
 
-  test("it exists", function (assert) {
-    const store = this.owner.lookup("service:store");
-    const serializer = store.serializerFor("document");
-
-    assert.ok(serializer);
-  });
-
   test("it serializes records", function (assert) {
     const store = this.owner.lookup("service:store");
-    const record = store.createRecord("document", {});
+    const record = store.createRecord("document", {
+      title: { en: "Foo" },
+      content: "test",
+    });
 
     const serializedRecord = record.serialize();
 
-    assert.ok(serializedRecord);
+    // content attribute should be removed
+    assert.deepEqual(serializedRecord, {
+      data: {
+        attributes: {
+          "created-at": undefined,
+          "created-by-group": undefined,
+          "created-by-user": undefined,
+          date: undefined,
+          description: {},
+          metainfo: undefined,
+          "modified-at": undefined,
+          "modified-by-group": undefined,
+          "modified-by-user": undefined,
+          title: {
+            en: "Foo",
+          },
+        },
+        type: "documents",
+      },
+    });
   });
 });

--- a/translations/en.yaml
+++ b/translations/en.yaml
@@ -17,7 +17,7 @@ alexandria:
         one {document}
         other {documents}
       }, an error occured.
-    update: "Your changes chould'nt be saved. Please try again."
+    update: "Your changes could not be saved. Please try again."
     no-permission: "You don't have permission to perform this action."
     move-document: "While moving {count, plural, one {the document} other {# documents}}, an error occured. Please try again."
     convert-pdf: "While converting, an error occured. Please try again."


### PR DESCRIPTION
prevents error from backend for trying to serialize the content attr when patching after an upload.

drive by translation fix