### PR TITLE
fix(css): selected color should win over striped table

### DIFF
--- a/app/styles/components/_document-list.scss
+++ b/app/styles/components/_document-list.scss
@@ -17,12 +17,10 @@
   user-select: none; /* Non-prefixed version, currently supported by Chrome, Edge, Opera and Firefox */
 }
 
-.document-list {
-  tr {
-    cursor: pointer;
-  }
+.document-list tr {
+  cursor: pointer;
+}
 
-  tr.document-list-item--selected {
-    background: #ffd;
-  }
+.uk-table.document-list tbody tr.document-list-item--selected {
+  background: #ffd;
 }


### PR DESCRIPTION
How it is:
![image](https://github.com/projectcaluma/ember-alexandria/assets/30687616/f35aaae9-74df-46d6-88e9-d2d47832b356)
What the fix does (restores previous look):
![image](https://github.com/projectcaluma/ember-alexandria/assets/30687616/d533649c-3e38-4430-ab3a-155ce52bb1c0)

Same 3 selected in both images
not quite sure why changing the css class path does this, probably something with precedence/ specificity winning when using the new path