### PR TITLE
feat(mark): display description

### DIFF
--- a/addon/components/mark-manager/mark.hbs
+++ b/addon/components/mark-manager/mark.hbs
@@ -1,4 +1,4 @@
-<label class="mark {{this.class}}" {{uk-tooltip @mark.name}}>
+<label class="mark {{this.class}}">
   <FaIcon @icon={{@mark.icon}} @fixedWidth={{true}} />
   <input
     type="checkbox"
@@ -8,3 +8,7 @@
     data-test-add-mark={{@mark.id}}
   />
 </label>
+<div uk-dropdown class="uk-padding-small mark__info-box">
+  <strong>{{@mark.name}}</strong>
+  <MarkdownToHtml @markdown={{@mark.description}} />
+</div>

--- a/app/styles/components/_document-details.scss
+++ b/app/styles/components/_document-details.scss
@@ -71,5 +71,10 @@
     &:hover {
       box-shadow: $tag-hover-shadow;
     }
+
+    &__info-box > div > p:last-child {
+      margin-bottom: 0;
+      max-width: 400px;
+    }
   }
 }


### PR DESCRIPTION
A description for some marks might be helpful. Currently they are not visible anywhere.
Display them like the description of the categories.

![image](https://github.com/projectcaluma/ember-alexandria/assets/30687616/9974307b-3229-41ad-8337-e1d22e0fe6e1)
Screenshot is weird, the tooltip should be visible above, but creating a screenshot hides it. Cursor is on middle mark.