### PR TITLE
fix: filter empty extensions in error message

### DIFF
--- a/addon/services/alexandria-documents.js
+++ b/addon/services/alexandria-documents.js
@@ -72,6 +72,7 @@ export default class AlexandriaDocumentsService extends Service {
             category: category.name,
             types: category.allowedMimeTypes
               .map((t) => mime.getExtension(t))
+              .filter(Boolean)
               .join(", "),
           }),
         );


### PR DESCRIPTION
It seems that not all mime types can be mapped to file extensions. The concrete case that triggered this fix was "image/vnd.dwg".