### PR TITLE
refactor(single-document-details): document title and edit title form

### DIFF
--- a/addon/components/single-document-details.hbs
+++ b/addon/components/single-document-details.hbs
@@ -20,7 +20,7 @@
     </label>
 
     <div
-      class="uk-flex uk-flex-middle uk-text-large uk-text-break"
+      class="uk-flex uk-flex-middle uk-text-break"
       data-test-title-container
     >
       <FaIcon
@@ -31,9 +31,9 @@
         {{set-style color=@document.category.color}}
       />
       {{#if this.editTitle}}
-        <form {{on "submit" (perform this.saveDocument)}}>
+        <form {{on "submit" (perform this.saveDocument)}} class="uk-flex uk-width-expand">
           <input
-            class="uk-input uk-width-auto
+            class="uk-input uk-width-expand
               {{unless this.validTitle 'uk-form-danger'}}"
             id="alexandria-details-title"
             type="text"
@@ -51,7 +51,7 @@
           ></button>
         </form>
       {{else}}
-        <span data-test-title>{{@document.title}}</span>
+        <span class="uk-text-bolder" data-test-title>{{@document.title}}</span>
       {{/if}}
     </div>
   </div>


### PR DESCRIPTION
- Smaller font size for the document title in the side panel (to accomodate for long file names)
- Fix responsive behavior of input field for edit title form

![image](https://github.com/user-attachments/assets/2d9e4e18-6bcf-41c4-870d-53301a5883ec)
