### PR TITLE
feat(copy): drag-drop shift modifier to move/copy a document

### DIFF
--- a/addon/components/category-nav/category.js
+++ b/addon/components/category-nav/category.js
@@ -82,6 +82,7 @@ export default class CategoryNavCategoryComponent extends Component {
   }
 
   onDrop = task({ drop: true }, async (event) => {
+    const dragAction = event.shiftKey ? "copy" : "move";
     event.preventDefault();
 
     if (!this.args.category.id) return;
@@ -90,7 +91,7 @@ export default class CategoryNavCategoryComponent extends Component {
     this.isDragOver = false;
 
     if (
-      event.dataTransfer.files.length &&
+      event.dataTransfer.files?.length &&
       !event.dataTransfer.getData("text")
     ) {
       return await this.documents.upload(
@@ -100,14 +101,29 @@ export default class CategoryNavCategoryComponent extends Component {
     }
 
     const documentIds = event.dataTransfer.getData("text").split(",");
-    const success = await this.documents.move(this.args.category, documentIds);
+
+    // copy or move to the category where the document(s) are dropped
+    const success =
+      "move" === dragAction
+        ? await this.documents.move(this.args.category, documentIds)
+        : await this.documents.copy(this.args.category, documentIds);
 
     const failCount = success.filter((i) => i === false).length;
-    const successCount = success.filter((i) => i === true).length;
+    let targetDocumentIds;
+    const successCount = success.filter(
+      (i) => i !== false && i !== "invalid-file-type",
+    ).length;
+    if ("move" === dragAction) {
+      targetDocumentIds = documentIds;
+    } else {
+      targetDocumentIds = success.filter(
+        (i) => i !== false && i !== "invalid-file-type",
+      );
+    }
 
     if (failCount) {
       this.notification.danger(
-        this.intl.t("alexandria.errors.move-document", {
+        this.intl.t(`alexandria.errors.${dragAction}-document`, {
           count: failCount,
         }),
       );
@@ -115,7 +131,7 @@ export default class CategoryNavCategoryComponent extends Component {
 
     if (successCount) {
       this.notification.success(
-        this.intl.t("alexandria.success.move-document", {
+        this.intl.t(`alexandria.success.${dragAction}-document`, {
           count: successCount,
         }),
       );
@@ -124,7 +140,7 @@ export default class CategoryNavCategoryComponent extends Component {
         queryParams: {
           category: this.args.category.id,
           search: undefined,
-          document: documentIds.join(","),
+          document: targetDocumentIds.join(","),
           tags: [],
           marks: [],
         },

--- a/addon/components/document-view.hbs
+++ b/addon/components/document-view.hbs
@@ -7,13 +7,12 @@
   >
     <div class="uk-flex uk-flex-middle uk-padding-small">
       <DocumentUploadButton
-        @categoryId={{@filters.category}}
+        @categoryId={{@filters.categories}}
         @afterUpload={{this.refreshDocumentList}}
         data-test-upload
       />
 
       <TagFilter
-        @category={{@filters.category}}
         @documents={{this.fetchedDocuments.value}}
         @selectedTags={{@filters.tags}}
         @selectedMarks={{@filters.marks}}
@@ -38,11 +37,10 @@
       {{on "dragleave" this.onDragLeave}}
       {{on "dragover" this.onDragOver}}
       {{on "drop" this.onDrop.perform}}
+      data-drop-documents
       ...attributes
     >
-      <div
-        class="document-view"
-      >
+      <div class="document-view">
         {{! List & Grid View }}
         {{#if @listView}}
           <DocumentList
@@ -73,9 +71,11 @@
         >
           {{#if this.onDrop.isRunning}}
             <UkSpinner />
-          {{else if this.canDrop}}
+          {{else if this.canDropCopy}}
+            {{t "alexandria.document-grid.drop-to-copy"}}
+          {{else if this.canDropUpload}}
             {{t "alexandria.document-grid.drop-to-upload"}}
-          {{else}}
+          {{else if (not this.dropAllowed)}}
             {{t "alexandria.document-grid.drop-not-allowed"}}
           {{/if}}
         </button>
@@ -91,6 +91,7 @@
 <div
   class="drag-info uk-background-default uk-box-shadow-medium uk-border-rounded uk-width-auto"
   {{did-insert this.registerDragInfo}}
->
-  {{t "alexandria.move-document" count=this.documents.selectedDocuments.length}}
-</div>
+>{{t
+    this.dragInfoTranslationKey
+    count=this.documents.selectedDocuments.length
+  }}</div>

--- a/addon/components/document-view.js
+++ b/addon/components/document-view.js
@@ -14,6 +14,7 @@ export default class DocumentViewComponent extends Component {
   @service("alexandria-config") config;
 
   @tracked isDragOver = false;
+  @tracked dragAction = "upload";
   @tracked dragCounter = 0;
   @tracked sort = "title";
   @tracked sortDirection = "";
@@ -32,7 +33,27 @@ export default class DocumentViewComponent extends Component {
   }
 
   get canDrop() {
-    return Boolean(this.args.filters && this.args.filters.category);
+    return this.canDropCopy || this.canDropUpload;
+  }
+
+  get canDropCopy() {
+    return Boolean(
+      this.dragAction === "copy" &&
+        this.args.filters &&
+        this.args.filters.categories,
+    );
+  }
+
+  get canDropUpload() {
+    return Boolean(
+      this.dragAction === "upload" &&
+        this.args.filters &&
+        this.args.filters.categories,
+    );
+  }
+
+  get dropAllowed() {
+    return ["copy", "upload"].includes(this.dragAction);
   }
 
   @action toggleView() {
@@ -114,7 +135,6 @@ export default class DocumentViewComponent extends Component {
     }
   }
 
-  // Drag'n'Drop document upload
   @action onDragEnter() {
     this.dragCounter++;
     this.isDragOver = true;
@@ -131,23 +151,45 @@ export default class DocumentViewComponent extends Component {
   }
 
   onDrop = task({ drop: true }, async (event) => {
-    if (!this.args.filters.category || !event.dataTransfer.files.length) {
+    this.dragAction = event.shiftKey ? "copy" : "move";
+    if (
+      this.dragAction === "move" &&
+      (!this.args.filters.categories || !event.dataTransfer.files?.length)
+    ) {
       this.dragCounter = 0;
       this.isDragOver = false;
+      this.dragAction = "upload";
       return;
     }
 
     event.preventDefault();
     event.stopPropagation();
 
-    await this.documents.upload(
-      this.args.filters.category,
-      event.dataTransfer.files,
-    );
-    this.refreshDocumentList();
-
+    // Copy documents to current category when dropped in document view.
     this.dragCounter = 0;
     this.isDragOver = false;
+
+    if ("copy" === this.dragAction) {
+      const documentIds = event.dataTransfer.getData("text").split(",");
+      const category = this.args.filters.categories;
+      if (0 === documentIds.length || !category) {
+        this.dragCounter = 0;
+        this.isDragOver = false;
+        this.dragAction = "upload";
+        return;
+      }
+
+      await this.documents.copy(category, documentIds);
+    } else {
+      // upload new files if it is a file(s) drop.
+      await this.documents.upload(
+        this.args.filters.categories,
+        event.dataTransfer.files,
+      );
+    }
+
+    this.refreshDocumentList();
+    this.dragAction = "upload";
   });
 
   // * DOCUMENT SELECTION
@@ -155,14 +197,19 @@ export default class DocumentViewComponent extends Component {
     if (this.documents.shortcutsDisabled) {
       return;
     }
+
     if (event.key === "a" && event.ctrlKey) {
       event.preventDefault();
       this.fetchedDocuments.value.forEach((doc) => {
         this.documents.selectDocument(doc);
       });
     }
+
     if (event.key === "Escape") {
       this.documents.clearDocumentSelection();
+      this.dragCounter = 0;
+      this.isDragOver = false;
+      this.dragAction = "upload";
     }
   }
 
@@ -229,6 +276,7 @@ export default class DocumentViewComponent extends Component {
   }
 
   @action dragDocument(document, event) {
+    this.dragAction = event.shiftKey ? "copy" : "move";
     if (!this.documents.selectedDocuments.includes(document)) {
       this.handleDocumentSelection(document, event);
     }
@@ -272,5 +320,13 @@ export default class DocumentViewComponent extends Component {
         sort: true,
       },
     };
+  }
+
+  get dragInfoTranslationKey() {
+    if ("upload" === this.dragAction) {
+      return false;
+    }
+
+    return `alexandria.${this.dragAction}-document`;
   }
 }

--- a/addon/services/alexandria-documents.js
+++ b/addon/services/alexandria-documents.js
@@ -194,6 +194,61 @@ export default class AlexandriaDocumentsService extends Service {
   }
 
   /**
+   * Copies one or multiple files.
+   *
+   * @param {Object} category category instance.
+   * @param {Array<Number>} documentIds.
+   */
+  async copy(category, documentIds) {
+    const INVALID_FILE_TYPE = "invalid-file-type";
+
+    const states = await Promise.all(
+      documentIds.map(async (id) => {
+        const originalDocument = this.store.peekRecord("document", id);
+        if (!originalDocument) {
+          return true;
+        }
+
+        if (!fileHasValidMimeType(originalDocument, category)) {
+          return "invalid-file-type";
+        }
+
+        const adapter = this.store.adapterFor("document");
+        let url = adapter.buildURL("document", originalDocument.id);
+        url += "/copy";
+
+        try {
+          const res = await this.fetch.fetch(url, {
+            method: "POST",
+            body: JSON.stringify({
+              data: {
+                type: "documents",
+                id: originalDocument.id,
+                category: category.id,
+              },
+            }),
+          });
+
+          return (await res.json()).data.id;
+        } catch (error) {
+          new ErrorHandler(this, error).notify();
+
+          return false;
+        }
+      }),
+    );
+
+    if (states.includes(INVALID_FILE_TYPE)) {
+      this.mimeTypeErrorNotification(category);
+      return states.map((state) =>
+        state === INVALID_FILE_TYPE ? false : state,
+      );
+    }
+
+    return states;
+  }
+
+  /**
    * Clears the document selection
    */
   @action clearDocumentSelection() {

--- a/tests/dummy/mirage/config.js
+++ b/tests/dummy/mirage/config.js
@@ -14,6 +14,23 @@ export default function makeServer(config) {
       this.post("/documents", function (schema) {
         return schema.documents.create();
       });
+      this.post("/documents/:id/copy", function (schema, request) {
+        const originalDocument = schema.documents.find(request.params.id);
+        const payload = JSON.parse(request.requestBody || "{}");
+        const category = payload?.data?.category
+          ? schema.categories.find(payload.data.category)
+          : originalDocument.category;
+
+        const input = {
+          ...originalDocument.attrs,
+        };
+        delete input.id;
+
+        return schema.documents.create({
+          ...input,
+          category,
+        });
+      });
       this.resource("tags", { except: ["delete"] });
       this.resource("marks", { only: ["index", "show"] });
 

--- a/tests/integration/components/category-nav/category-test.js
+++ b/tests/integration/components/category-nav/category-test.js
@@ -56,6 +56,7 @@ module("Integration | Component | category-nav/category", function (hooks) {
     );
 
     await triggerEvent("[data-test-drop]", "drop", {
+      shiftKey: false,
       dataTransfer: {
         getData: () => documents.map((d) => d.id).join(","),
         // sometimes browser send a file as well (e.g. when dragging a thumbnail) - this should be ignored
@@ -73,12 +74,65 @@ module("Integration | Component | category-nav/category", function (hooks) {
         tags: [],
       },
     });
+
     // Since the mimetype of the second one doesn't match the default allowed
     // mime types of the category factories, only one file should be moved.
     assert.deepEqual(
       documents.map((d) => d.category.id),
       [category.id, oldCategory.id],
     );
+  });
+
+  test("it copies dropped documents to a category", async function (assert) {
+    const category = this.server.create("category");
+    const oldCategory = this.server.create("category");
+    const documents = this.server.createList("document", 2, {
+      categoryId: oldCategory.id,
+      title: "test.txt",
+    });
+    const documentIds = documents.map((d) => `${d.id}`);
+
+    const store = this.owner.lookup("service:store");
+
+    this.category = await store.findRecord("category", category.id);
+    await store.findAll("document"); // the code uses peekRecord
+
+    const router = this.engine.lookup("service:router");
+
+    stub(router, "currentRouteName").get(() => null);
+    router.transitionTo = fake();
+
+    await render(
+      hbs`<CategoryNav::Category @category={{this.category}} data-test-drop />`,
+      { owner: this.engine },
+    );
+
+    await triggerEvent("[data-test-drop]", "drop", {
+      shiftKey: true,
+      dataTransfer: {
+        getData: () => documents.map((d) => d.id).join(","),
+        // sometimes browser send a file as well (e.g. when dragging a thumbnail) - this should be ignored
+        files: [new File(["Thumbnail"], "test-file.docx")],
+      },
+    });
+
+    const allDocumentIds = this.server.schema.documents
+      .all()
+      .models.map((d) => `${d.id}`);
+    const newDocumentIds = allDocumentIds.filter(
+      (d) => !documentIds.includes(d),
+    );
+
+    assert.strictEqual(router.transitionTo.callCount, 1);
+    assert.deepEqual(router.transitionTo.args[0][1], {
+      queryParams: {
+        category: category.id,
+        document: newDocumentIds.join(),
+        marks: [],
+        search: undefined,
+        tags: [],
+      },
+    });
   });
 
   test("it uploads on drop", async function (assert) {

--- a/tests/integration/components/document-view-test.js
+++ b/tests/integration/components/document-view-test.js
@@ -1,4 +1,4 @@
-import { render } from "@ember/test-helpers";
+import { render, triggerEvent } from "@ember/test-helpers";
 import { setupRenderingTest } from "dummy/tests/helpers";
 import { hbs } from "ember-cli-htmlbars";
 import { setupMirage } from "ember-cli-mirage/test-support";
@@ -56,5 +56,41 @@ module("Integration | Component | document-view", function (hooks) {
       include: "category,files,tags",
       sort: "title",
     });
+  });
+
+  test("copy documents within category", async function (assert) {
+    const category = this.server.create("category", {
+      allowedMimeTypes: ["image/png"],
+    });
+    const documents = this.server.createList("document", 3, {
+      categoryId: category.id,
+      title: "test.png",
+    });
+
+    const docService = this.engine.lookup("service:alexandria-documents");
+    this.filters = { categories: category.id };
+
+    const docSelection = documents.slice(0, 2);
+    docService.selectedDocuments = docSelection;
+
+    await render(
+      hbs`
+          <DocumentView @listView={{ false }} @filters={{ this.filters }} />`,
+      {
+        owner: this.engine,
+      },
+    );
+
+    assert.dom("[data-test-empty]").doesNotExist();
+    assert.dom("[data-test-document]").exists({ count: 3 });
+
+    await triggerEvent("[data-drop-documents]", "drop", {
+      shiftKey: true,
+      dataTransfer: {
+        getData: () => docSelection.map((d) => d.id).join(","),
+      },
+    });
+
+    assert.dom("[data-test-document]").exists({ count: 5 });
   });
 });

--- a/translations/de.yaml
+++ b/translations/de.yaml
@@ -7,6 +7,7 @@ alexandria:
   upload-file: "Datei hochladen"
   download: "Download"
   move-document: "{count} {count, plural, one {Dokument} other {Dokumente}} verschieben"
+  copy-document: "{count} {count, plural, one {Dokument} other {Dokumente}} kopieren"
 
   errors:
     save-file: "Beim Herunterladen der Datei ist ein Fehler aufgetreten. Bitte versuchen Sie es erneut."
@@ -21,6 +22,7 @@ alexandria:
     update: "Änderungen konnten nicht gespeichert werden. Versuchen Sie es erneut."
     no-permission: "Sie haben keine Berechtigung, diese Aktion auszuführen."
     move-document: "Beim Verschieben {count, plural, one {des Dokumentes} other {von # Dokumenten}} ist ein Fehler aufgetreten"
+    copy-document: "Beim Kopieren {count, plural, one {des Dokumentes} other {von # Dokumenten}} ist ein Fehler aufgetreten"
     convert-pdf: "Während dem Umwandeln ist ein Fehler aufgetreten."
     invalid-file-type: 'In der Kategorie "{category}" können nur {types} hochgeladen werden.'
     file-too-large: "Die hochgeladene Datei ist zu gross."
@@ -35,6 +37,7 @@ alexandria:
       } erfolgreich hochgeladen.
     update: "Änderungen wurden gespeichert."
     move-document: "{count, plural, one {Das Dokument wurde} other {# Dokumente wurden}} erfolgreich verschoben"
+    copy-document: "{count, plural, one {Das Dokument wurde} other {# Dokumente wurden}} erfolgreich kopiert"
     convert-pdf: "Dokument wurde erfolgreich umgewandelt."
 
   category-nav:
@@ -53,6 +56,7 @@ alexandria:
       confirm: "Löschen"
 
   document-grid:
+    drop-to-copy: "Dokument fallen lassen, um es zu kopieren"
     drop-to-upload: "Datei fallen lassen, um sie hochzuladen"
     drop-not-allowed: "Keine Kategorie ausgewählt"
 

--- a/translations/en.yaml
+++ b/translations/en.yaml
@@ -7,6 +7,7 @@ alexandria:
   upload-file: "Upload file"
   download: "Download"
   move-document: "Move {count} {count, plural, one {document} other {documents}}"
+  copy-document: "Copy {count} {count, plural, one {document} other {documents}}"
 
   errors:
     save-file: "While downloading the document, an error occured. Please try again."
@@ -21,6 +22,7 @@ alexandria:
     update: "Your changes could not be saved. Please try again."
     no-permission: "You don't have permission to perform this action."
     move-document: "While moving {count, plural, one {the document} other {# documents}}, an error occured. Please try again."
+    copy-document: "While copying {count, plural, one {the document} other {# documents}}, an error occured. Please try again."
     convert-pdf: "While converting, an error occured. Please try again."
     invalid-file-type: 'In category "{category}" only {types} can be uploaded.'
     file-too-large: "The uploaded file is too large."
@@ -35,6 +37,7 @@ alexandria:
       } uploaded successfully.
     update: "Changes saved."
     move-document: "{count, plural, one {Document} other {# documents}} moved successfully"
+    copy-document: "{count, plural, one {Document} other {# documents}} copied successfully"
     convert-pdf: "Document converted successfully."
 
   category-nav:
@@ -53,6 +56,7 @@ alexandria:
       confirm: "Delete"
 
   document-grid:
+    drop-to-copy: "Drop document to copy"
     drop-to-upload: "Drop file to upload"
     drop-not-allowed: "No category selected"
 

--- a/translations/it.yaml
+++ b/translations/it.yaml
@@ -7,6 +7,7 @@ alexandria:
   upload-file: "Carica file"
   download: "Download"
   move-document: "Sposta {count} {count, plural, one {documento} other {documenti}}"
+  copy-document: "Copia {count} {count, plural, one {documento} other {documenti}}"
 
   errors:
     save-file: "Errore nel tentativo di scaricare il file. Riprova"
@@ -14,12 +15,13 @@ alexandria:
     fetch-categories: "Errore nel tentativo di caricare le categorie."
     replace-document: "Errore nel tentativo di sostituire il documento."
     upload-document: |-
-      Errore nel tentativo di caricare 
+      Errore nel tentativo di caricare
       {count, plural, one {il documento}
         other {i documenti}}.
     update: "Non è stato possibile salvare le modifiche. Riprova"
     no-permission: "Non dispone dei diritti per eseguire questa operazione."
     move-document: "Errore nel tentativo di spostare {count, plural, one {il documento} other {i documenti}}"
+    copy-document: "Errore nel tentativo di copiare {count, plural, one {il documento} other {i documenti}}"
     convert-pdf: "Errore nel tentativo di convertire il documento."
     invalid-file-type: 'Nella categoria "{category}" è possibile caricare solo {types}.'
     file-too-large: "Il file caricato è troppo grande."
@@ -34,6 +36,7 @@ alexandria:
       } con successo.
     update: "Le modifiche sono state salvate."
     move-document: "{count, plural, one {Il documento è stato spostato} other {# I documenti sono stati spostati}} con successo"
+    copy-document: "{count, plural, one {Il documento è stato copiato} other {# I documenti sono stati copiati}} con successo"
     convert-pdf: "Il documento è stato convertito con successo."
 
   category-nav:
@@ -52,6 +55,7 @@ alexandria:
       confirm: "Elimina"
 
   document-grid:
+    drop-to-copy: "Trascina qui il documento per copiarlo"
     drop-to-upload: "Trascina qui il file per caricarlo"
     drop-not-allowed: "Nessuna categoria selezionata"
 


### PR DESCRIPTION
Adding a new feature to allow copying documents together with the underlying files.

While holding shift you can either drag the document(s) onto the document view (to copy within the same category), or onto a category by dropping it onto the category navigation on the left.

This functionality will rely on https://github.com/projectcaluma/alexandria/pull/757
