### PR TITLE
fix(documents): add mimeType lookup for mimeType/file-extension check

### DIFF
--- a/addon/services/alexandria-documents.js
+++ b/addon/services/alexandria-documents.js
@@ -13,15 +13,26 @@ import { ErrorHandler } from "ember-alexandria/utils/error-handler";
  */
 function fileHasValidMimeType(file, category) {
   if (!category.allowedMimeTypes) {
+    console.warn("fileHasValidMimeType: all types allowed");
     return true;
   }
 
   if (file instanceof File) {
     // newly uploaded files that do not have a model yet
+    console.warn(
+      "fileHasValidMimeType: file instanceof File",
+      file.type,
+      category.allowedMimeTypes.includes(file.type),
+    );
     return category.allowedMimeTypes.includes(file.type);
   }
 
   // existing file models
+  console.warn(
+    "fileHasValidMimeType: existing file models",
+    file.mimeType,
+    category.allowedMimeTypes.includes(file.mimeType),
+  );
   return category.allowedMimeTypes.includes(file.mimeType);
 }
 export default class AlexandriaDocumentsService extends Service {

--- a/addon/services/alexandria-documents.js
+++ b/addon/services/alexandria-documents.js
@@ -13,7 +13,7 @@ import { ErrorHandler } from "ember-alexandria/utils/error-handler";
  */
 const fileHasValidMimeType = (file, category) =>
   category.allowedMimeTypes?.includes(
-    file.type || mime.getType(file.name ?? file.title),
+    file.mimeType || mime.getType(file.name ?? file.title),
   ) ?? true;
 
 export default class AlexandriaDocumentsService extends Service {
@@ -160,7 +160,8 @@ export default class AlexandriaDocumentsService extends Service {
           return true;
         }
 
-        if (!fileHasValidMimeType(document, newCategory)) {
+        const files = (await document.files) ?? [];
+        if (files.some((file) => !fileHasValidMimeType(file, newCategory))) {
           return "invalid-file-type";
         }
 

--- a/addon/services/alexandria-documents.js
+++ b/addon/services/alexandria-documents.js
@@ -18,9 +18,7 @@ function fileHasValidMimeType(file, category) {
 
   if (file instanceof File) {
     // newly uploaded files that do not have a model yet
-    return category.allowedMimeTypes.includes(
-      file.type || mime.getType(file.name),
-    );
+    return category.allowedMimeTypes.includes(file.type);
   }
 
   // existing file models
@@ -173,7 +171,7 @@ export default class AlexandriaDocumentsService extends Service {
         const files = (await document.files) ?? [];
         if (
           files
-            .filter((f) => f.variant !== "thumbnail")
+            .filter((f) => f.variant === "original")
             .some((file) => !fileHasValidMimeType(file, newCategory))
         ) {
           return "invalid-file-type";

--- a/addon/services/alexandria-documents.js
+++ b/addon/services/alexandria-documents.js
@@ -13,26 +13,15 @@ import { ErrorHandler } from "ember-alexandria/utils/error-handler";
  */
 function fileHasValidMimeType(file, category) {
   if (!category.allowedMimeTypes) {
-    console.warn("fileHasValidMimeType: all types allowed");
     return true;
   }
 
   if (file instanceof File) {
     // newly uploaded files that do not have a model yet
-    console.warn(
-      "fileHasValidMimeType: file instanceof File",
-      file.type,
-      category.allowedMimeTypes.includes(file.type),
-    );
     return category.allowedMimeTypes.includes(file.type);
   }
 
   // existing file models
-  console.warn(
-    "fileHasValidMimeType: existing file models",
-    file.mimeType,
-    category.allowedMimeTypes.includes(file.mimeType),
-  );
   return category.allowedMimeTypes.includes(file.mimeType);
 }
 export default class AlexandriaDocumentsService extends Service {

--- a/tests/acceptance/documents-test.js
+++ b/tests/acceptance/documents-test.js
@@ -170,7 +170,9 @@ module("Acceptance | documents", function (hooks) {
         });
     });
     await triggerEvent("[data-test-upload] [data-test-input]", "change", {
-      files: [new File(["Ember Rules!"], "test-file.txt")],
+      files: [
+        new File(["Ember Rules!"], "test-file.txt", { type: "text/plain" }),
+      ],
     });
     assert.dom("[data-test-document-list-item]").exists({ count: 1 });
   });

--- a/tests/integration/components/category-nav/category-test.js
+++ b/tests/integration/components/category-nav/category-test.js
@@ -38,18 +38,22 @@ module("Integration | Component | category-nav/category", function (hooks) {
     const documents = this.server.createList("document", 2, {
       categoryId: oldCategory.id,
       title: "TestTextFile",
-      files: this.server.createList("file", 1, {
-        name: "test.txt",
-        mimeType: "text/plain",
-      }),
+      files: [
+        this.server.create("file", {
+          name: "test.txt",
+          mimeType: "text/plain",
+        }),
+      ],
     });
     // Case 2: File with not allowed mimeType
-    documents[1].update({
+    await documents[1].update({
       title: "TestVid",
-      files: this.server.createList("file", 1, {
-        name: "TestVid.jpg",
-        mimeType: "video/webm",
-      }),
+      files: [
+        this.server.create("file", {
+          name: "TestVid.jpg",
+          mimeType: "video/webm",
+        }),
+      ],
     });
 
     const store = this.owner.lookup("service:store");
@@ -71,7 +75,9 @@ module("Integration | Component | category-nav/category", function (hooks) {
       dataTransfer: {
         getData: () => documents.map((d) => d.id).join(","),
         // sometimes browser send a file as well (e.g. when dragging a thumbnail) - this should be ignored
-        files: [new File(["Thumbnail"], "test-file.docx")],
+        files: [
+          new File(["Thumbnail"], "test-file.txt", { type: "text/plain" }),
+        ],
       },
     });
 
@@ -85,7 +91,7 @@ module("Integration | Component | category-nav/category", function (hooks) {
         tags: [],
       },
     });
-    // Since the mimetype of the third one doesn't match the default allowed
+    // Since the mimetype of the second one doesn't match the default allowed
     // mime types of the category factories, only one file should be moved.
     assert.deepEqual(
       documents.map((d) => d.category.id),

--- a/tests/integration/components/category-nav/category-test.js
+++ b/tests/integration/components/category-nav/category-test.js
@@ -52,7 +52,7 @@ module("Integration | Component | category-nav/category", function (hooks) {
         title: "TestVid",
         files: [
           this.server.create("file", {
-            name: "TestVid.jpg",
+            name: "TestVid.webm",
             mimeType: "video/webm",
           }),
         ],
@@ -73,10 +73,6 @@ module("Integration | Component | category-nav/category", function (hooks) {
       { owner: this.engine },
     );
 
-    assert.deepEqual(
-      documents.map((d) => d.category.id),
-      [oldCategory.id, oldCategory.id],
-    );
     await triggerEvent("[data-test-drop]", "drop", {
       dataTransfer: {
         getData: () => documents.map((d) => d.id).join(","),

--- a/tests/integration/components/category-nav/category-test.js
+++ b/tests/integration/components/category-nav/category-test.js
@@ -35,24 +35,16 @@ module("Integration | Component | category-nav/category", function (hooks) {
     const category = this.server.create("category");
     const oldCategory = this.server.create("category");
     // Case 1: File with ext in name & allowed mimType
-    const documents = this.server.createList("document", 3, {
+    const documents = this.server.createList("document", 2, {
       categoryId: oldCategory.id,
-      title: "test.txt",
+      title: "TestTextFile",
       files: this.server.createList("file", 1, {
         name: "test.txt",
         mimeType: "text/plain",
       }),
     });
-    // Case 2: File with allowed mimeType
+    // Case 2: File with not allowed mimeType
     documents[1].update({
-      title: "TestGif",
-      files: this.server.createList("file", 1, {
-        name: "TestFileWithoutEXT",
-        mimeType: "image/gif",
-      }),
-    });
-    // Case 3: File with allowed ext in name, but not allowed mimeType
-    documents[2].update({
       title: "TestVid",
       files: this.server.createList("file", 1, {
         name: "TestVid.jpg",
@@ -97,7 +89,7 @@ module("Integration | Component | category-nav/category", function (hooks) {
     // mime types of the category factories, only one file should be moved.
     assert.deepEqual(
       documents.map((d) => d.category.id),
-      [category.id, category.id, oldCategory.id],
+      [category.id, oldCategory.id],
     );
   });
 

--- a/tests/integration/components/category-nav/category-test.js
+++ b/tests/integration/components/category-nav/category-test.js
@@ -34,28 +34,30 @@ module("Integration | Component | category-nav/category", function (hooks) {
   test("it moves dropped documents to new category", async function (assert) {
     const category = this.server.create("category");
     const oldCategory = this.server.create("category");
-    // Case 1: File with ext in name & allowed mimType
-    const documents = this.server.createList("document", 2, {
-      categoryId: oldCategory.id,
-      title: "TestTextFile",
-      files: [
-        this.server.create("file", {
-          name: "test.txt",
-          mimeType: "text/plain",
-        }),
-      ],
-    });
-    // Case 2: File with not allowed mimeType
-    await documents[1].update({
-      title: "TestVid",
-      files: [
-        this.server.create("file", {
-          name: "TestVid.jpg",
-          mimeType: "video/webm",
-        }),
-      ],
-    });
-
+    const documents = [
+      // Case 1: File with ext in name & allowed mimType
+      this.server.create("document", {
+        categoryId: oldCategory.id,
+        title: "TestTextFile",
+        files: [
+          this.server.create("file", {
+            name: "test.txt",
+            mimeType: "text/plain",
+          }),
+        ],
+      }),
+      // Case 2: File with not allowed mimeType
+      this.server.create("document", {
+        categoryId: oldCategory.id,
+        title: "TestVid",
+        files: [
+          this.server.create("file", {
+            name: "TestVid.jpg",
+            mimeType: "video/webm",
+          }),
+        ],
+      }),
+    ];
     const store = this.owner.lookup("service:store");
 
     this.category = await store.findRecord("category", category.id);
@@ -71,6 +73,10 @@ module("Integration | Component | category-nav/category", function (hooks) {
       { owner: this.engine },
     );
 
+    assert.deepEqual(
+      documents.map((d) => d.category.id),
+      [oldCategory.id, oldCategory.id],
+    );
     await triggerEvent("[data-test-drop]", "drop", {
       dataTransfer: {
         getData: () => documents.map((d) => d.id).join(","),

--- a/tests/integration/components/category-nav/category-test.js
+++ b/tests/integration/components/category-nav/category-test.js
@@ -34,11 +34,31 @@ module("Integration | Component | category-nav/category", function (hooks) {
   test("it moves dropped documents to new category", async function (assert) {
     const category = this.server.create("category");
     const oldCategory = this.server.create("category");
-    const documents = this.server.createList("document", 2, {
+    // Case 1: File with ext in name & allowed mimType
+    const documents = this.server.createList("document", 3, {
       categoryId: oldCategory.id,
       title: "test.txt",
+      files: this.server.createList("file", 1, {
+        name: "test.txt",
+        mimeType: "text/plain",
+      }),
     });
-    documents[1].update({ title: "test.xlsx" });
+    // Case 2: File with allowed mimeType
+    documents[1].update({
+      title: "TestGif",
+      files: this.server.createList("file", 1, {
+        name: "TestFileWithoutEXT",
+        mimeType: "image/gif",
+      }),
+    });
+    // Case 3: File with allowed ext in name, but not allowed mimeType
+    documents[2].update({
+      title: "TestVid",
+      files: this.server.createList("file", 1, {
+        name: "TestVid.jpg",
+        mimeType: "video/webm",
+      }),
+    });
 
     const store = this.owner.lookup("service:store");
 
@@ -73,11 +93,11 @@ module("Integration | Component | category-nav/category", function (hooks) {
         tags: [],
       },
     });
-    // Since the mimetype of the second one doesn't match the default allowed
+    // Since the mimetype of the third one doesn't match the default allowed
     // mime types of the category factories, only one file should be moved.
     assert.deepEqual(
       documents.map((d) => d.category.id),
-      [category.id, oldCategory.id],
+      [category.id, category.id, oldCategory.id],
     );
   });
 

--- a/tests/unit/services/alexandria-documents-test.js
+++ b/tests/unit/services/alexandria-documents-test.js
@@ -15,10 +15,13 @@ module("Unit | Service | alexandria-documents", function (hooks) {
       "category",
       this.server.create("category").id,
     );
+
+    const docxMimeType =
+      "application/vnd.openxmlformats-officedocument.wordprocessingml.document";
     const files = [
-      new File(["1"], "test1.docx"),
-      new File(["2"], "test2.docx"),
-      new File(["3"], "test3.docx"),
+      new File(["1"], "test1.docx", { type: docxMimeType }),
+      new File(["2"], "test2.docx", { type: docxMimeType }),
+      new File(["3"], "test3.docx", { type: docxMimeType }),
     ];
 
     await service.upload(category, files);


### PR DESCRIPTION
The current lookup for the mimeType was just done by checking the name / file-extension in the name, which lead to errors when moving documents to other categories when someone changed the name of the document to something without an valid extension

e.g.
1. File "ABC.pdf" was uploaded
2. ABC renamed to "ABC"
3. User wants to move it to other category => failed

This PR fixes this, so that the File could be moved even when it's named "ABC", because it is checking the explicit mimeType (which was determined by the libmagic python lib in the backend)