### PR TITLE
feat(delete): trigger delete button with keyboard

### DIFF
--- a/addon/components/multi-document-details.hbs
+++ b/addon/components/multi-document-details.hbs
@@ -34,6 +34,7 @@
           @color="danger"
           class="uk-width-1"
           {{on "click" showDialog}}
+          {{did-insert (fn this.registerDeleteDialog showDialog)}}
         >
           {{t "alexandria.delete"}}
         </UkButton>

--- a/addon/components/multi-document-details.js
+++ b/addon/components/multi-document-details.js
@@ -1,7 +1,39 @@
+import { action } from "@ember/object";
 import { inject as service } from "@ember/service";
 import Component from "@glimmer/component";
+import { tracked } from "@glimmer/tracking";
+
 export default class MultiDocumentDetailsComponent extends Component {
   @service("alexandria-side-panel") sidePanel;
+  @service("alexandria-documents") documents;
+  @tracked deleteDialog = null;
+
+  constructor(parent, args) {
+    super(parent, args);
+
+    this.boundHandleKeyDown = this.handleKeyDown.bind(this);
+    window.addEventListener("keydown", this.boundHandleKeyDown);
+  }
+
+  @action
+  registerDeleteDialog(showDialog) {
+    this.deleteDialog = showDialog;
+  }
+
+  willDestroy() {
+    super.willDestroy();
+    window.removeEventListener("keydown", this.boundHandleKeyDown);
+  }
+
+  handleKeyDown(event) {
+    if (this.documents.shortcutsDisabled) {
+      return;
+    }
+
+    if (event.key === "Delete" && this.deleteDialog) {
+      this.deleteDialog();
+    }
+  }
 
   get mergedTags() {
     const tags = [];

--- a/addon/components/single-document-details.hbs
+++ b/addon/components/single-document-details.hbs
@@ -249,6 +249,7 @@
           @color="danger"
           class="uk-width-1"
           {{on "click" showDialog}}
+          {{did-insert (fn this.registerDeleteDialog showDialog)}}
         >
           {{t "alexandria.delete"}}
         </UkButton>

--- a/addon/components/single-document-details.js
+++ b/addon/components/single-document-details.js
@@ -20,6 +20,34 @@ export default class SingleDocumentDetailsComponent extends Component {
   @tracked editDescription = false;
   @tracked editDate = false;
   @tracked validTitle = true;
+  @tracked deleteDialog = null;
+
+  constructor(parent, args) {
+    super(parent, args);
+
+    this.boundHandleKeyDown = this.handleKeyDown.bind(this);
+    window.addEventListener("keydown", this.boundHandleKeyDown);
+  }
+
+  @action
+  registerDeleteDialog(showDialog) {
+    this.deleteDialog = showDialog;
+  }
+
+  willDestroy() {
+    super.willDestroy();
+    window.removeEventListener("keydown", this.boundHandleKeyDown);
+  }
+
+  handleKeyDown(event) {
+    if (this.documents.shortcutsDisabled) {
+      return;
+    }
+
+    if (event.key === "Delete" && this.deleteDialog) {
+      this.deleteDialog();
+    }
+  }
 
   get locale() {
     return this.intl.primaryLocale.split("-")[0];


### PR DESCRIPTION
Implemented a keyboard shortcut to delete selected documents. This would fix https://github.com/projectcaluma/ember-alexandria/issues/741

Current implementation would trigger the `DocumentDeleteButton` in the `single-document-details`/`multi-document-details` components  as all the logic for the modal currently resides in the button component.