### PR TITLE
feat(document-details): show original filename

### DIFF
--- a/addon/components/single-document-details.hbs
+++ b/addon/components/single-document-details.hbs
@@ -54,6 +54,19 @@
         <span class="uk-text-bolder" data-test-title>{{@document.title}}</span>
       {{/if}}
     </div>
+    {{#if
+      (and
+        this.originalFilename.value
+        (not (eq this.originalFilename.value @document.title))
+      )
+    }}
+      <div data-test-original-filename>
+        <span class="uk-text-bolder">
+          {{t "alexandria.document-details.original-filename"}}:
+        </span>
+        {{this.originalFilename.value}}
+      </div>
+    {{/if}}
   </div>
 
   <MarkManager @documents={{array @document}} class="uk-margin" />

--- a/addon/components/single-document-details.js
+++ b/addon/components/single-document-details.js
@@ -4,6 +4,7 @@ import Component from "@glimmer/component";
 import { tracked } from "@glimmer/tracking";
 import { task } from "ember-concurrency";
 import { DateTime } from "luxon";
+import { trackedFunction } from "reactiveweb/function";
 
 import { ErrorHandler } from "ember-alexandria/utils/error-handler";
 
@@ -20,6 +21,19 @@ export default class SingleDocumentDetailsComponent extends Component {
   @tracked editDescription = false;
   @tracked editDate = false;
   @tracked validTitle = true;
+
+  originalFilename = trackedFunction(this, async () => {
+    if (!this.config.enableOriginalDocumentFilename) {
+      return false;
+    }
+
+    return (await this.args.document.files)
+      .filter((f) => f.variant === "original")
+      .sort((a, b) => {
+        return new Date(b.createdAt) - new Date(a.createdAt);
+      })
+      .pop()?.name;
+  });
 
   get locale() {
     return this.intl.primaryLocale.split("-")[0];

--- a/addon/services/alexandria-config.js
+++ b/addon/services/alexandria-config.js
@@ -8,6 +8,7 @@ export default class AlexandriaConfigService extends Service {
 
   enablePDFConversion = false;
   enableWebDAV = false;
+  enableOriginalDocumentFilename = false;
   allowedWebDAVMimeTypes = [
     "application/vnd.openxmlformats-officedocument.wordprocessingml.document",
     "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet",

--- a/tests/acceptance/documents-test.js
+++ b/tests/acceptance/documents-test.js
@@ -95,6 +95,26 @@ module("Acceptance | documents", function (hooks) {
 
   test("document detail edit title", async function (assert) {
     const document = this.server.create("document");
+    this.server.create("file", {
+      variant: "original",
+      name: "some-file-after-1.pdf",
+      createdAt: new Date(2025, 2, 1),
+      document,
+    });
+    // oldest original file
+    const originalFile = this.server.create("file", {
+      variant: "original",
+      name: document.title,
+      createdAt: new Date(2025, 1, 1),
+      document,
+    });
+    this.server.create("file", {
+      variant: "original",
+      name: "some-other-after-2.pdf",
+      createdAt: new Date(2025, 3, 1),
+      document,
+    });
+
     await visit(`/`);
     await click("[data-test-toggle-side-panel]");
     setLocale("en");
@@ -108,6 +128,7 @@ module("Acceptance | documents", function (hooks) {
       .hasText(document.title);
 
     assert.dom("[data-test-title-input]").doesNotExist();
+    assert.dom("[data-test-original-filename]").doesNotExist();
 
     await click("[data-test-single-doc-details] [data-test-edit-title]");
     assert.dom("[data-test-title-input]").hasValue(document.title);
@@ -127,6 +148,10 @@ module("Acceptance | documents", function (hooks) {
     });
     await click("[data-test-single-doc-details] [data-test-save]");
     assert.dom("[data-test-title-input]").doesNotExist();
+    assert.dom("[data-test-original-filename]").exists();
+    assert
+      .dom("[data-test-original-filename]")
+      .containsText(`Original: ${originalFile.name}`);
   });
 
   test("document detail delete", async function (assert) {

--- a/tests/dummy/app/services/alexandria-config.js
+++ b/tests/dummy/app/services/alexandria-config.js
@@ -10,6 +10,7 @@ export default class CustomAlexandriaConfigService extends AlexandriaConfigServi
 
   enablePDFConversion = true;
   enableWebDAV = true;
+  enableOriginalDocumentFilename = true;
   additionalFileTypes = {
     json: {
       icon: "file-code",

--- a/translations/de.yaml
+++ b/translations/de.yaml
@@ -97,6 +97,7 @@ alexandria:
       text: "Text"
       video: "Video"
       word: "Word"
+    original-filename: "Original"
 
   document-download:
     button: "{numDocs, plural, =1 {Herunterladen} other {Auswahl herunterladen}}"

--- a/translations/en.yaml
+++ b/translations/en.yaml
@@ -98,6 +98,7 @@ alexandria:
       text: "Text"
       video: "Video"
       word: "Word"
+    original-filename: "Original"
 
   document-download:
     button: "{numDocs, plural, =1 {Download} other {Download selection}}"

--- a/translations/it.yaml
+++ b/translations/it.yaml
@@ -97,6 +97,7 @@ alexandria:
       text: "Testo"
       video: "Video"
       word: "Word"
+    original-filename: "Originale"
 
   document-download:
     button: "{numDocs, plural, =1 {Scarica} other {Scarica elementi selezionati}}"


### PR DESCRIPTION
When the document title does not match the original filename, show the original filename in the single document details.