### PR TITLE
fix(upload): only show success notification on successful upload

### DIFF
--- a/addon/services/alexandria-documents.js
+++ b/addon/services/alexandria-documents.js
@@ -146,7 +146,7 @@ export default class AlexandriaDocumentsService extends Service {
       new ErrorHandler(this, error).notify("alexandria.errors.upload-document");
     });
 
-    if (!muteNotification) {
+    if (successes.length > 0 && !muteNotification) {
       this.notification.success(
         this.intl.t("alexandria.success.upload-document", {
           count: successes.length,


### PR DESCRIPTION
When an error occurs during the upload of a file, the success notification should not be shown.

**Example:**

![image](https://github.com/user-attachments/assets/fe63f90f-0034-4115-ae6c-c381c0bb8047)

However, on multi-upload the the notification may be shown if at least one upload was succesful, e.g.:

![image](https://github.com/user-attachments/assets/d10f0856-997d-4362-9472-85e1484a2660)
