### PR TITLE
feat(category): add query params to category endpoint

### DIFF
--- a/addon/components/category-nav.js
+++ b/addon/components/category-nav.js
@@ -6,9 +6,11 @@ export default class CategoryNavComponent extends Component {
   @service store;
   @service notification;
   @service intl;
+  @service("alexandria-config") config;
 
   categories = query(this, "category", () => ({
     "filter[hasParent]": false,
     include: "children",
+    ...this.config.categoryQueryParameters,
   }));
 }

--- a/addon/components/document-upload-button.js
+++ b/addon/components/document-upload-button.js
@@ -8,10 +8,12 @@ export default class DocumentUploadButtonComponent extends Component {
   @service intl;
   @service store;
   @service("alexandria-documents") documents;
+  @service("alexandria-config") config;
 
   categories = query(this, "category", () => ({
     "filter[hasParent]": false,
     include: "children",
+    ...this.config.categoryQueryParameters,
   }));
 
   get category() {

--- a/addon/services/alexandria-config.js
+++ b/addon/services/alexandria-config.js
@@ -34,6 +34,10 @@ export default class AlexandriaConfigService extends Service {
     return {};
   }
 
+  get categoryQueryParameters() {
+    return {};
+  }
+
   get defaultModelMeta() {
     return {};
   }

--- a/tests/dummy/app/services/alexandria-config.js
+++ b/tests/dummy/app/services/alexandria-config.js
@@ -1,6 +1,6 @@
 import { action } from "@ember/object";
 import { service } from "@ember/service";
-import { macroCondition, isTesting } from "@embroider/macros";
+import { isTesting, macroCondition } from "@embroider/macros";
 import { dedupeTracked } from "tracked-toolbox";
 
 import AlexandriaConfigService from "ember-alexandria/services/alexandria-config";
@@ -35,6 +35,10 @@ export default class CustomAlexandriaConfigService extends AlexandriaConfigServi
         ],
       };
     }
+    return {};
+  }
+
+  get categoryQueryParameters() {
     return {};
   }
 


### PR DESCRIPTION
Create a config `categoryQueryParameters` value like the `modelMetaFilters` to optionally provide extra query parameters when fetching categories.

This would allow to override the config and provide extra query parameters to provide more context when fetching categories.