### PR TITLE
feat: ask to create copy in target category when moving a document

### DIFF
--- a/translations/de.yaml
+++ b/translations/de.yaml
@@ -24,8 +24,8 @@ alexandria:
     file-too-large: "Die hochgeladene Datei ist zu gross."
     open-webdav: "Dokument konnte nicht zum Bearbeiten geöffnet werden."
     move-failed: |-
-      "Sie haben keine Rechte das Dokument "{documentTitle}" nach "{categoryName}" zu verschieben. 
-      Möchten Sie es stattdessen nach "{categoryName}" kopieren?"
+      Sie haben keine Rechte {count, plural, one {das Dokument "{documentTitle}"} other {die Dokumente}} nach "{categoryName}" zu verschieben. 
+      Möchten Sie {count, plural, one {es} other {diese}} stattdessen nach "{categoryName}" kopieren?
 
   success:
     delete-document: "Das Dokument wurde erfolgreich gelöscht."

--- a/translations/de.yaml
+++ b/translations/de.yaml
@@ -23,6 +23,9 @@ alexandria:
     invalid-file-type: 'In der Kategorie "{category}" können nur {types} hochgeladen werden.'
     file-too-large: "Die hochgeladene Datei ist zu gross."
     open-webdav: "Dokument konnte nicht zum Bearbeiten geöffnet werden."
+    move-failed: |-
+      "Sie haben keine Rechte das Dokument "{documentTitle}" nach "{categoryName}" zu verschieben. 
+      Möchten Sie es stattdessen nach "{categoryName}" kopieren?"
 
   success:
     delete-document: "Das Dokument wurde erfolgreich gelöscht."

--- a/translations/en.yaml
+++ b/translations/en.yaml
@@ -23,6 +23,9 @@ alexandria:
     invalid-file-type: 'In category "{category}" only {types} can be uploaded.'
     file-too-large: "The uploaded file is too large."
     open-webdav: "Document could not be opened to be edited."
+    move-failed: |-
+      "You do not have the rights to move the document "{documentTitle}" to "{categoryName}". 
+      Would you like to copy it to "{categoryName}" instead?"
 
   success:
     delete-document: "Document deleted successfully"

--- a/translations/en.yaml
+++ b/translations/en.yaml
@@ -24,8 +24,8 @@ alexandria:
     file-too-large: "The uploaded file is too large."
     open-webdav: "Document could not be opened to be edited."
     move-failed: |-
-      "You do not have the rights to move the document "{documentTitle}" to "{categoryName}". 
-      Would you like to copy it to "{categoryName}" instead?"
+      You do not have the rights to move the {count, plural, one {document "{documentTitle}"} other {documents}} to "{categoryName}". 
+      Would you like to copy {count, plural, one {it} other {them}} to "{categoryName}" instead?
 
   success:
     delete-document: "Document deleted successfully"

--- a/translations/it.yaml
+++ b/translations/it.yaml
@@ -24,8 +24,8 @@ alexandria:
     file-too-large: "Il file caricato è troppo grande."
     open-webdav: "Non è stato possibile aprire il documento per l'elaborazione."
     move-failed: |-
-      "Non hai i diritti per spostare il documento "{documentTitle}" in "{categoryName}". 
-      Vuoi copiarlo invece in "{categoryName}"?"
+      Non hai i diritti {count, plural, one {per spostare il documento "{documentTitle}"} other {per spostare i documenti}} in "{categoryName}". 
+      Vuoi {count, plural, one {copiarlo} other {copiarli}} invece in "{categoryName}"?
 
   success:
     delete-document: "Il documento è stato eliminato con successo."

--- a/translations/it.yaml
+++ b/translations/it.yaml
@@ -23,6 +23,9 @@ alexandria:
     invalid-file-type: 'Nella categoria "{category}" è possibile caricare solo {types}.'
     file-too-large: "Il file caricato è troppo grande."
     open-webdav: "Non è stato possibile aprire il documento per l'elaborazione."
+    move-failed: |-
+      "Non hai i diritti per spostare il documento "{documentTitle}" in "{categoryName}". 
+      Vuoi copiarlo invece in "{categoryName}"?"
 
   success:
     delete-document: "Il documento è stato eliminato con successo."


### PR DESCRIPTION
Currently we have the problem, that when you move a document to a category, where you don't have permission to see it, it won't show in the target category. Therefore we denied it in the permission layer, but to give the user a chance to move / copy it anyways we want to provide him a new confirm-dialog, in which the user can decide to create a copy of the chosen document in that target category - but only if the user has no permission to move the document.

![image](https://github.com/user-attachments/assets/e5b03870-be23-4917-adf6-1b5c45c0b7a9)
