### PR TITLE
fix(error-handling): rollback new models on failed creation

### DIFF
--- a/addon/components/category-nav/category.js
+++ b/addon/components/category-nav/category.js
@@ -55,7 +55,7 @@ export default class CategoryNavCategoryComponent extends Component {
       );
       const matchesCategory =
         !categoryIds || categoryIds.includes(doc.belongsTo("category").id());
-      return matchesMeta && matchesCategory;
+      return !doc.isNew && matchesMeta && matchesCategory;
     }).length;
   });
 
@@ -121,11 +121,13 @@ export default class CategoryNavCategoryComponent extends Component {
         event.dataTransfer.files,
       );
 
-      this.router.transitionTo(this.router.currentRouteName, {
-        queryParams: {
-          category: this.args.category.id,
-        },
-      });
+      if (uploaded.length) {
+        this.router.transitionTo(this.router.currentRouteName, {
+          queryParams: {
+            category: this.args.category.id,
+          },
+        });
+      }
 
       return uploaded;
     }

--- a/addon/components/document-upload-button.js
+++ b/addon/components/document-upload-button.js
@@ -21,9 +21,9 @@ export default class DocumentUploadButtonComponent extends Component {
   }
 
   upload = task(async (category, { target: { files = [] } = {} }) => {
-    await this.documents.upload(category, files);
+    const uploaded = await this.documents.upload(category, files);
 
-    if (this.args.afterUpload) {
+    if (this.args.afterUpload && uploaded.length) {
       this.args.afterUpload();
     }
   });

--- a/addon/components/document-view.js
+++ b/addon/components/document-view.js
@@ -193,8 +193,14 @@ export default class DocumentViewComponent extends Component {
     event.preventDefault();
     event.stopPropagation();
 
-    await this.documents.upload(this.args.category, event.dataTransfer.files);
-    this.refreshDocumentList();
+    const uploaded = await this.documents.upload(
+      this.args.category,
+      event.dataTransfer.files,
+    );
+
+    if (uploaded.length) {
+      this.refreshDocumentList();
+    }
 
     this.dragCounter = 0;
     this.isDragOver = false;

--- a/addon/services/alexandria-documents.js
+++ b/addon/services/alexandria-documents.js
@@ -98,7 +98,15 @@ export default class AlexandriaDocumentsService extends Service {
       });
       // must be set outside for localized model
       documentModel.title = file.name;
-      await documentModel.save();
+
+      try {
+        await documentModel.save();
+      } catch (e) {
+        // Remove the new model from the store if the upload failed
+        documentModel.unloadRecord();
+        throw e;
+      }
+
       return documentModel;
     },
   );

--- a/tests/integration/components/category-nav/category-test.js
+++ b/tests/integration/components/category-nav/category-test.js
@@ -104,7 +104,7 @@ module("Integration | Component | category-nav/category", function (hooks) {
   test("it uploads on drop", async function (assert) {
     const category = this.server.create("category");
     const store = this.engine.lookup("service:store");
-    const fakeUpload = fake();
+    const fakeUpload = fake.returns([1]);
     this.engine.lookup("service:alexandria-documents").upload = fakeUpload;
 
     const router = this.engine.lookup("service:router");


### PR DESCRIPTION
This fixes the document counter that currently increases even though the upload failed. Also, we now only refresh the whole list if there was a successfull upload.