### PR TITLE
fix(ui): add category label text break

### DIFF
--- a/addon/components/category-nav/category.hbs
+++ b/addon/components/category-nav/category.hbs
@@ -35,7 +35,11 @@
           />
         {{/if}}
       </div>
-      <div data-test-name data-test-category-id={{@category.id}}>
+      <div
+        class="uk-text-break uk-overflow-hidden"
+        data-test-name
+        data-test-category-id={{@category.id}}
+      >
         {{@category.name}}
       </div>
       {{#if @category.description}}


### PR DESCRIPTION
Since the addition with the category counts some labels don't fit anymore (when there are no spaces in the label).

**Before:**

<img width="331" height="366" alt="image" src="https://github.com/user-attachments/assets/73c5ffa6-eb7d-4c44-ab02-20ab29d06295" />

**After:**

<img width="306" height="381" alt="image" src="https://github.com/user-attachments/assets/cfd4882b-e0d7-4929-99d9-8b1a00dc0846" />
