### PR TITLE
fix(error-handling): handle fetch error notifications correctly

### DIFF
--- a/addon/components/multi-document-details.js
+++ b/addon/components/multi-document-details.js
@@ -34,15 +34,17 @@ export default class MultiDocumentDetailsComponent extends Component {
   copyDocuments = task({ drop: true }, async (event) => {
     event?.preventDefault();
     try {
-      await this.documents.copy(
+      const result = await this.documents.copy(
         this.args.selectedDocuments.map((doc) => doc.id),
       );
-      await this.args.refreshDocumentList();
-      this.notification.success(
-        this.intl.t("alexandria.success.copy-document", {
-          count: this.args.selectedDocuments.length,
-        }),
-      );
+      if (result.filter((r) => r === true).length > 0) {
+        await this.args.refreshDocumentList();
+        this.notification.success(
+          this.intl.t("alexandria.success.copy-document", {
+            count: this.args.selectedDocuments.length,
+          }),
+        );
+      }
     } catch (error) {
       new ErrorHandler(this, error).notify("alexandria.errors.copy-document", {
         count: this.args.selectedDocuments.length,

--- a/addon/components/single-document-details.js
+++ b/addon/components/single-document-details.js
@@ -174,11 +174,13 @@ export default class SingleDocumentDetailsComponent extends Component {
   copyDocument = task({ drop: true }, async (event) => {
     event?.preventDefault();
     try {
-      await this.documents.copy([this.args.document.id]);
-      await this.args.refreshDocumentList();
-      this.notification.success(
-        this.intl.t("alexandria.success.copy-document", { count: 1 }),
-      );
+      const result = await this.documents.copy([this.args.document.id]);
+      if (result.filter((r) => r === true).length > 0) {
+        await this.args.refreshDocumentList();
+        this.notification.success(
+          this.intl.t("alexandria.success.copy-document", { count: 1 }),
+        );
+      }
     } catch (error) {
       new ErrorHandler(this, error).notify("alexandria.errors.copy-document", {
         count: 1,

--- a/addon/utils/error-handler.js
+++ b/addon/utils/error-handler.js
@@ -7,7 +7,13 @@ export class ErrorHandler {
 
   constructor(context, error) {
     setOwner(this, getOwner(context));
-    this.error = error;
+
+    // error triggered by fetch is mapped differently.
+    if (error?.cause) {
+      this.error = { errors: error.cause };
+    } else {
+      this.error = error;
+    }
   }
 
   notify(...args) {

--- a/tests/dummy/app/services/fetch.js
+++ b/tests/dummy/app/services/fetch.js
@@ -31,7 +31,9 @@ export default class FetchService extends Service {
         return this.session.handleUnauthorized();
       }
 
-      const contentType = response.headers.map["content-type"];
+      const contentType = response.headers?.map
+        ? response.headers.map["content-type"]
+        : response.headers?.get("content-type");
       let body = "";
 
       if (


### PR DESCRIPTION
When permission is denied (403 response) while copying a document or multiple documents it currently always shows a success message.

<img width="2034" height="687" alt="image" src="https://github.com/user-attachments/assets/bbe018cc-b45d-4ca2-b4d6-50ecaa932395" />

Copying files is handled by `AlexandriaDocumentsService` and returns an array of boolean success statuses (it will handle error notifications itself). So calling the copy method won't raise an error when there is a failure. Therefore I changed it so that single / multi file copy is considered okay if at least one `true` is returned.

A few extra needed fixes, when the error originates from a call made by the fetch service instead of a model save operation:

-  `FetchService`: `response.headers.map["content-type"]` raises an error because `headers.map` doesn't exist. Added a fallback for `response.headers.get` instead. (see error in screenshot)
- `ErrorHandler`: the returned error through the `FetchService` is set in `cause` instead of being an `errors` list, remapped it in the constructor so it can get the error type correctly.

<img width="2031" height="667" alt="image" src="https://github.com/user-attachments/assets/6d26e495-36f0-4442-bc48-18b08412fa29" />
